### PR TITLE
[codex] calibrate prompt cache audit context

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 `audit-prompt-caching` is a portable Codex/agent skill for finding why LLM cache reuse fails across the request path: prompt/prefix caches, provider cache telemetry, cache-aware routing, agent tool stability, Bedrock checkpoints, OpenRouter routing drift, provider migration risk, and vLLM/SGLang KV reuse.
 
+## Updates And Field Notes
+
+I share practical notes on building AI platforms, agent infrastructure, prompt-cache audits, and production lessons in the [Telegram channel](https://t.me/+ymZhCIjiWyYzZTVi).
+
 ## Why This Exists
 
 LLM cache reuse usually fails silently. A timestamp in the system prompt, shuffled tool schemas, a changed first user message, an OpenRouter fallback, or a new vLLM replica can turn repeated 20k-token requests into cold prefill again.

--- a/audit-prompt-caching/SKILL.md
+++ b/audit-prompt-caching/SKILL.md
@@ -71,6 +71,19 @@ Bundled fixtures are only demo and regression-test data. Do not require users to
 
 This skill does not capture or intercept live traffic by itself. If telemetry is needed, ask the user to export or redact representative records from their own logging, tracing, provider dashboard, or billing pipeline.
 
+## Project Context Gate
+
+Before assigning severity or recommending project changes, review hot paths, repeat cadence, prompt families, and cache applicability. Identify which LLM routes are frequent enough, long enough, repeated enough, stable enough, and safe enough for prompt/prefix caching to matter.
+
+Do this before deep provider advice:
+
+1. Map prompt families, request builders, model/provider routes, agent loops, deployment paths, and usage frequency.
+2. Separate hot repeated paths from rare jobs, one-off prompts, admin flows, experiments, and prompt families that cannot share a stable prefix.
+3. Mark each finding as applicable, conditionally applicable, or not applicable to the project path under review.
+4. Ask for telemetry only after code/config context shows the evidence needed next.
+
+If project context shows a route runs rarely, changes prompt families often, has no stable long prefix, or is dominated by output/tool latency, say prompt caching is not the right lever for that route. Do not keep generic cache warnings in the findings list after they are known to be not applicable.
+
 ## Applicability Gate
 
 Before recommending prompt-cache changes, check:
@@ -83,6 +96,10 @@ Before recommending prompt-cache changes, check:
 6. **Safety boundary**: Would broader cache reuse violate tenant, privacy, data residency, ZDR, or side-channel requirements?
 
 If the gate fails, report why caching is not the right lever yet and recommend measurement, prompt restructuring, routing fixes, or a different optimization.
+
+## Language Match Rule
+
+Answer in the user's language by default. Preserve provider/API field names exactly, such as `cached_tokens`, `cache_control`, `cachePoint`, `TTFT`, `prompt_cache_key`, and `response_format`, but explain their meaning in the user's language instead of switching the report into English. If the user asks in Russian, headings, severity explanations, and recommendations should be in Russian unless they are literal API names or quoted code.
 
 ## Agent-First Output Contracts
 
@@ -119,6 +136,12 @@ source | severity | provider/engine | issue | evidence | evidence_type | confide
 ```
 
 Use evidence types such as `confirmed from code`, `confirmed from telemetry`, `provider-doc hypothesis`, or `needs validation`. State impact conditions like "matters if this path is hot, repeated, and has a long stable prefix" instead of implying guaranteed savings. Include one safe first action, one validation metric/command, and one thing not to do yet when the next risky change would be premature.
+
+For review-style responses, keep the result compact and project-specific:
+
+1. **Confirmed findings**: issues supported by code/config/telemetry and applicable to the project path.
+2. **Hypotheses**: plausible cache risks that need usage logs, rendered payloads, route metrics, or provider docs before severity can rise.
+3. **Not applicable**: generic cache advice that the project context rules out, such as prefix-cache work for a once-daily prompt family with no meaningful repeated stable prefix.
 
 ## Explicit Review Default
 
@@ -165,6 +188,12 @@ Use scripts when deterministic evidence is better than prose:
 - `scripts/run_trigger_eval.py`: summarize positive and negative trigger-eval coverage from `evals/trigger_eval.json`.
 
 Do not treat these scripts as provider tokenizers or billing truth. Provider usage and billing exports remain authoritative.
+
+### Script Transparency Rule
+
+Before running any bundled script, explain what each bundled script reads, writes, and whether it uses network. Also state why the script is needed, whether it scans the whole repository or a targeted path, and the expected runtime class: seconds, tens of seconds, or minutes.
+
+Default to a targeted scan when the repo is large or the user asked a narrow question. If a script may read secrets, environment files, generated artifacts, large logs, or production exports, say that explicitly and ask for approval unless the user has already requested that exact scan. Do not send files to a network service from these scripts. If network access is needed for provider docs or package installation, treat it as a separate explicit action.
 
 ## Freshness Gate
 
@@ -240,6 +269,12 @@ Use this taxonomy to keep audits consistent:
 | P4 | Reporting | file-line findings, before/after prompt layout, ROI assumptions, validation commands |
 
 ## Severity
+
+### Applicability Before Severity
+
+Assign severity only after the Project Context Gate and Applicability Gate. A real anti-pattern in cold, sparse, single-run, output-bound, or non-cacheable routes is not automatically a high-severity cache finding.
+
+Do not mark prefix-cache findings high severity without evidence that the affected route is hot, repeated within cache lifetime, has a long stable prefix, and has meaningful input-cost or TTFT impact. If those conditions are unknown, use `medium`, `low`, or `needs validation`, and state exactly what telemetry would raise or lower the severity.
 
 Assign severity from impact and evidence, not from the anti-pattern name alone:
 

--- a/audit-prompt-caching/evals/evals.json
+++ b/audit-prompt-caching/evals/evals.json
@@ -210,6 +210,18 @@
       "prompt": "OpenRouter audit found dynamic user profile data in the first system message and a session_id in the first user message. The reviewer wants to add a stable first user anchor, pin provider.order, and add cache_control everywhere. We have no traffic, token, routed provider, or cached_tokens telemetry yet. What should the audit recommend?",
       "expected_output": "Uses the evidence-bearing output contract with Measurement change, Prompt behavior change, Provider/routing change, Confidence, Do first, and Do not do yet; marks code findings as confirmed from code but cache impact as needs validation or provider-doc hypothesis until telemetry exists; treats a stable first non-system operation anchor as an OpenRouter A/B experiment for hot repeated operations, not a guaranteed cache fix; recommends observability first with first-message HMAC hashes, routed provider/model or generation metadata, cached_tokens, cache_write_tokens, and usage.cost; does not pin providers, add cache_control everywhere, or overstate high severity without traffic/token evidence.",
       "files": []
+    },
+    {
+      "id": 36,
+      "prompt": "Use $audit-prompt-caching. Сделай ревью на русском. В проекте 7 prompt families, большинство запросов запускается once per day, часть промптов вообще не имеет длинного стабильного prefix. Предыдущий аудит нашел high risk по prefix cache, но не изучил специфику проекта. Что нужно сказать пользователю?",
+      "expected_output": "Answers in Russian and keeps API/provider fields literal; starts with the Project Context Gate by mapping prompt families, hot paths, repeat cadence, and where prefix caching is applicable; separates confirmed findings from hypotheses and not applicable generic advice; preserves valid telemetry findings when code confirms missing cache metrics; do not mark prefix-cache findings high severity until a route is hot, repeated, long-prefix, and cost/TTFT-relevant; says once per day jobs and prompt families without stable repeated prefixes are likely not worth prompt-cache work except for measurement or documentation.",
+      "files": []
+    },
+    {
+      "id": 37,
+      "prompt": "The user is worried that the audit skill ran a repository script for a minute or two and did not explain what it was doing. They now ask whether to run extract_llm_calls.py and layout_linter.py on a large private repo. How should the skill behave?",
+      "expected_output": "Uses the Script Transparency Rule before running scripts; explains what each script reads, what it writes, whether it uses network, expected runtime, and why the scan is needed; prefers targeted paths or a small first scan before whole-repo scans; states that bundled audit scripts must not send repo files to a network service; asks for approval before scans that may read secrets, environment files, generated artifacts, large logs, or production exports.",
+      "files": []
     }
   ]
 }

--- a/docs/superpowers/plans/2026-05-08-project-context-calibration.md
+++ b/docs/superpowers/plans/2026-05-08-project-context-calibration.md
@@ -1,0 +1,159 @@
+# Project Context Calibration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `audit-prompt-caching` audits project-aware, language-matched, and transparent about script execution before recommending cache changes.
+
+**Architecture:** Keep the skill package shape unchanged. Add behavior guidance to `SKILL.md`, lock it with focused unittest assertions, and add eval pressure cases for project-specific severity calibration and script transparency.
+
+**Tech Stack:** Markdown skill docs, JSON eval fixtures, Python stdlib `unittest`.
+
+---
+
+### Task 1: Guardrail Tests
+
+**Files:**
+- Modify: `tests/test_prompt_cache_scripts.py`
+
+- [x] **Step 1: Add skill guidance assertions**
+
+Add a unittest that reads `audit-prompt-caching/SKILL.md` and asserts the new guardrails are present:
+
+```python
+def test_skill_requires_project_context_language_and_script_transparency(self):
+    skill = (ROOT / "audit-prompt-caching" / "SKILL.md").read_text()
+
+    for required in [
+        "Project Context Gate",
+        "Language Match Rule",
+        "Script Transparency Rule",
+        "Applicability Before Severity",
+        "review hot paths, repeat cadence, prompt families, and cache applicability",
+        "explain what each bundled script reads, writes, and whether it uses network",
+    ]:
+        self.assertIn(required, skill)
+```
+
+- [x] **Step 2: Add eval coverage assertions**
+
+Add a unittest that requires eval prompts/expected output to cover Russian review, project-specific severity calibration, daily jobs, and script transparency:
+
+```python
+def test_evals_cover_project_context_and_script_transparency_feedback(self):
+    evals = json.loads(
+        (ROOT / "audit-prompt-caching" / "evals" / "evals.json").read_text()
+    )
+    combined = "\n".join(
+        item["prompt"] + "\n" + item["expected_output"] for item in evals["evals"]
+    )
+
+    for required in [
+        "Сделай ревью на русском",
+        "7 prompt families",
+        "once per day",
+        "Script Transparency Rule",
+        "do not mark prefix-cache findings high severity",
+    ]:
+        self.assertIn(required, combined)
+```
+
+- [x] **Step 3: Run targeted tests for RED**
+
+Run:
+
+```bash
+python3 -m unittest \
+  tests.test_prompt_cache_scripts.PromptCacheScriptsTest.test_skill_requires_project_context_language_and_script_transparency \
+  tests.test_prompt_cache_scripts.PromptCacheScriptsTest.test_evals_cover_project_context_and_script_transparency_feedback
+```
+
+Expected: FAIL because `SKILL.md` and `evals.json` do not yet contain the new feedback guardrails.
+
+### Task 2: Skill Behavior Guidance
+
+**Files:**
+- Modify: `audit-prompt-caching/SKILL.md`
+
+- [x] **Step 1: Add Project Context Gate**
+
+Insert a section before `Applicability Gate` requiring the agent to identify project-specific prompt/cache topology before assigning severity:
+
+```markdown
+## Project Context Gate
+
+Before assigning severity or recommending project changes, review hot paths, repeat cadence, prompt families, and cache applicability. Identify which LLM routes are frequent enough, long enough, repeated enough, and stable enough for prefix caching to matter.
+```
+
+- [x] **Step 2: Add Applicability Before Severity**
+
+Extend severity guidance so findings are not `high` without hot path, cadence, token, telemetry, or cost/TTFT evidence.
+
+- [x] **Step 3: Add Language Match Rule**
+
+Require responses to use the user's language while preserving provider/API field names.
+
+- [x] **Step 4: Add Script Transparency Rule**
+
+Document that bundled scripts require a short pre-run explanation covering read scope, write scope, network behavior, expected runtime, and why the script is needed.
+
+- [x] **Step 5: Add concise review shape**
+
+Require compact review outputs to separate `confirmed findings`, `hypotheses`, and `not applicable` findings.
+
+### Task 3: Eval Pressure Cases
+
+**Files:**
+- Modify: `audit-prompt-caching/evals/evals.json`
+
+- [x] **Step 1: Add Russian project-context calibration eval**
+
+Add an eval where the user asks in Russian for review of a narrow project with 7 prompt families and daily jobs. Expected output must answer in Russian, inspect project specifics first, lower severity when caching is not applicable, and keep telemetry findings separate from hypotheses.
+
+- [x] **Step 2: Add script transparency eval**
+
+Add an eval where the user is concerned about a long-running audit script. Expected output must explain read/write/network/runtime scope before running scripts, prefer targeted scans first, and avoid secret-scanning behavior unless explicitly needed and explained.
+
+### Task 4: Verification
+
+**Files:**
+- No source modifications expected.
+
+- [x] **Step 1: Run targeted tests**
+
+```bash
+python3 -m unittest \
+  tests.test_prompt_cache_scripts.PromptCacheScriptsTest.test_skill_requires_project_context_language_and_script_transparency \
+  tests.test_prompt_cache_scripts.PromptCacheScriptsTest.test_evals_cover_project_context_and_script_transparency_feedback
+```
+
+- [x] **Step 2: Run full script test suite**
+
+```bash
+python3 -m unittest tests/test_prompt_cache_scripts.py
+```
+
+- [x] **Step 3: Validate package and trigger eval**
+
+```bash
+python3 audit-prompt-caching/scripts/validate_skill_package.py audit-prompt-caching
+python3 audit-prompt-caching/scripts/run_trigger_eval.py audit-prompt-caching
+```
+
+- [x] **Step 4: Check Python syntax**
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+for path in [*Path('audit-prompt-caching/scripts').glob('*.py'), *Path('tests').glob('*.py')]:
+    compile(path.read_text(), str(path), 'exec')
+    print(f'ok {path}')
+PY
+```
+
+- [x] **Step 5: Check whitespace and generated bytecode**
+
+```bash
+git diff --check
+find . -name __pycache__ -type d -prune -exec rm -rf {} +
+find . \( -name __pycache__ -o -name '*.pyc' \) -print
+```

--- a/tests/test_prompt_cache_scripts.py
+++ b/tests/test_prompt_cache_scripts.py
@@ -1001,6 +1001,36 @@ class PromptCacheScriptsTest(unittest.TestCase):
         ]:
             self.assertIn(required, combined_prompts + "\n" + combined_expected)
 
+    def test_skill_requires_project_context_language_and_script_transparency(self):
+        skill = (ROOT / "audit-prompt-caching" / "SKILL.md").read_text()
+
+        for required in [
+            "Project Context Gate",
+            "Language Match Rule",
+            "Script Transparency Rule",
+            "Applicability Before Severity",
+            "review hot paths, repeat cadence, prompt families, and cache applicability",
+            "explain what each bundled script reads, writes, and whether it uses network",
+        ]:
+            self.assertIn(required, skill)
+
+    def test_evals_cover_project_context_and_script_transparency_feedback(self):
+        evals = json.loads(
+            (ROOT / "audit-prompt-caching" / "evals" / "evals.json").read_text()
+        )
+        combined = "\n".join(
+            item["prompt"] + "\n" + item["expected_output"] for item in evals["evals"]
+        )
+
+        for required in [
+            "Сделай ревью на русском",
+            "7 prompt families",
+            "once per day",
+            "Script Transparency Rule",
+            "do not mark prefix-cache findings high severity",
+        ]:
+            self.assertIn(required, combined)
+
     def test_anthropic_reference_covers_current_prompt_cache_semantics(self):
         reference = (
             ROOT / "audit-prompt-caching" / "references" / "anthropic.md"


### PR DESCRIPTION
## What changed

- Added project-context calibration guidance to `audit-prompt-caching/SKILL.md`.
- Added language matching and script transparency rules for audit responses.
- Added eval coverage for Russian project-specific review and long-running script trust concerns.
- Added tests that lock the new guardrails into the package checks.
- Added the implementation plan under `docs/superpowers/plans/`.

## Why

User feedback showed that cache audit findings could be too generic, too English-heavy for Russian requests, and too opaque when bundled scripts run for a while. The skill now requires agents to understand project hot paths, prompt families, repeat cadence, and cache applicability before assigning severity or recommending prompt-cache changes.

## Impact

Agents using this skill should produce more project-specific audits, avoid overstating high-severity prefix-cache findings without traffic/token/TTFT evidence, and explain bundled script behavior before scanning private repositories.

## Validation

- `python3 -m unittest tests/test_prompt_cache_scripts.py`
- `python3 audit-prompt-caching/scripts/validate_skill_package.py audit-prompt-caching`
- `python3 audit-prompt-caching/scripts/run_trigger_eval.py audit-prompt-caching`
- Python syntax compile for `audit-prompt-caching/scripts/*.py` and `tests/*.py`
- `git diff --check`
- Removed and rechecked generated `__pycache__` / `*.pyc` artifacts