### PR TITLE
Add Vercel AI SDK and Mastra references

### DIFF
--- a/audit-prompt-caching/SKILL.md
+++ b/audit-prompt-caching/SKILL.md
@@ -230,6 +230,8 @@ Search SDK imports, API base URLs, model names, deployment manifests, and config
 | `dashscope`, `qwen`, `bailian`, `aliyun` | Qwen/DashScope | `references/qwen.md` |
 | `yandexgpt`, `foundationModels`, `llm.api.cloud.yandex.net` | YandexGPT | `references/yandexgpt.md` |
 | `z.ai`, `zai`, `glm-`, `api.z.ai` | z.ai | `references/zai.md` |
+| `@mastra/core`, `@mastra/memory`, `@mastra/ai-sdk`, `mastra.ai`, `agent.generate`, `agent.stream`, `workingMemory`, `semanticRecall`, `MCPClient` | Mastra | `references/mastra.md` |
+| `@ai-sdk/anthropic`, `@ai-sdk/openai`, `@ai-sdk/amazon-bedrock`, `@ai-sdk/google`, `generateText`, `streamText`, `generateObject`, `providerOptions`, `experimental_providerMetadata`, `createAnthropic`, `createOpenAI` | Vercel AI SDK | `references/vercel-ai-sdk.md` |
 
 Load only the relevant provider files. If OpenRouter, Azure, or Bedrock signals appear alongside OpenAI/Anthropic-compatible calls, prefer the router/provider wrapper reference over the generic direct-provider reference. If detection is ambiguous, ask which provider/engine is in use.
 

--- a/audit-prompt-caching/references/mastra.md
+++ b/audit-prompt-caching/references/mastra.md
@@ -1,0 +1,168 @@
+# Mastra Prefix Cache Reference
+
+## Documentation Freshness
+
+Last reviewed: 2026-05-26.
+
+Verify before exact claims:
+- `Agent` constructor option shape for `instructions`, `tools`, `memory`, `model`
+- `agent.generate(...)` / `agent.stream(...)` option shape, especially `providerOptions` carry-over
+- `@mastra/memory` injection behavior: working memory placement, semantic recall position, `lastMessages` window
+- `MCPClient.listTools()` ordering guarantees and `toolsets` dynamic loading shape
+- `ResponseCache` processor scope semantics (`scope: null` vs per-user `MASTRA_RESOURCE_ID_KEY`)
+- which `ai` and `@ai-sdk/<provider>` majors the installed `@mastra/core` actually depends on
+
+Official sources:
+- Agents reference: https://mastra.ai/reference/agents/agent
+- Memory overview: https://mastra.ai/docs/memory/overview
+- Working memory: https://mastra.ai/docs/memory/working-memory
+- Semantic recall: https://mastra.ai/docs/memory/semantic-recall
+- Response caching: https://mastra.ai/docs/agents/response-caching
+- MCP client reference: https://mastra.ai/reference/tools/mcp-client
+- Provider options pattern (Anthropic example): https://mastra.ai/docs/models/providers/anthropic
+
+## Stable Mechanics
+
+Mastra is layered on Vercel AI SDK; load `references/vercel-ai-sdk.md` for the wire-level cache mechanics and provider behavior. Mastra adds Agent, Memory, Workflow, and ResponseCache surfaces that independently affect prefix stability and telemetry.
+
+`Agent.generate(...)` and `Agent.stream(...)` return AI SDK result objects (`GenerateTextResult`, `StreamTextResult`). Mastra's agent loop can call the model multiple times per `generate` (initial → tool result → continuation), so the SDK-level rollup of cache fields is a sum across internal HTTP calls, not a per-request value.
+
+## Provider Checks
+
+### Detect Mastra Before Generic Vercel AI SDK
+
+Mastra wraps the AI SDK but introduces its own surfaces (`Agent`, `Memory`, `Workflow`, `createTool`, `MCPClient`) that the AI SDK reference does not cover. Detection signals:
+
+```bash
+rg -n "@mastra/|from ['\"]@mastra|new Agent\(|Agent\(\{|agent\.generate\(|agent\.stream\(|new Memory\(|workingMemory|semanticRecall|MCPClient|createTool\(|createWorkflow\(" .
+```
+
+If present, load this reference and `references/vercel-ai-sdk.md` together; the underlying provider reference is still required for wire-level cache mechanics.
+
+### instructions Is Re-Evaluated When It Is A Function
+
+`Agent.instructions` accepts a string, an array of system messages, or a function `({ runtimeContext, mastra }) => string | SystemMessage[]`. Function form runs on every `generate()` / `stream()` call.
+
+Deterministic functions produce byte-stable wire payloads; cache still works. The audit risk is volatile content interpolated into the function body. Worst-case failure shape:
+
+```ts
+new Agent({
+  instructions: () => `Current time: ${new Date().toISOString()}\n\n${STATIC_BASE}`,
+  model,
+})
+```
+
+With `providerOptions.anthropic.cacheControl` on `agent.generate(...)`, both calls write a new cache entry (`cache_creation_input_tokens > 0`) and neither reads (`cache_read_input_tokens == 0`). Net cost: input plus the 1.25× cache-write premium on every call, zero savings.
+
+Audit grep:
+
+```bash
+rg -n "instructions\s*:\s*\(|instructions\s*:\s*async\s*\(|tools\s*:\s*\(\s*\{|runtimeContext" .
+```
+
+For every function-form `instructions` or `tools`, follow the value chain and confirm the returned text does not interpolate `Date`, `now`, `uuid`, `randomUUID`, `runtimeContext.user.*`, `cwd`, `env`, or randomized few-shot selections. Move volatile content into a user-role message and keep `instructions` static.
+
+### agent.generate({ providerOptions }) Lands At The Top Of The Wire Body
+
+Cache directives are configured in user code via `providerOptions`. The auditable question is where AI SDK puts that directive on the wire after Mastra forwards it. When `providerOptions` is passed at the call site (not on the `instructions` object), the directive ends up at the top level of the Anthropic request body, not on a specific block.
+
+User code:
+
+```ts
+agent.generate(USER_QUERY, {
+  providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+});
+```
+
+Resulting wire body sent to `https://api.anthropic.com/v1/messages` (captured via a logging `fetch`):
+
+```json
+{
+  "model": "claude-sonnet-4-5",
+  "max_tokens": 64000,
+  "cache_control": { "type": "ephemeral" },
+  "system": [{ "type": "text", "text": "..." }],
+  "messages": [...],
+  "tools": [{ "name": "...", ... }]
+}
+```
+
+Top-level `cache_control` is not in the public Anthropic API spec. Anthropic accepts it and the cache engages. Auditable consequences:
+
+- precise per-block anchoring (cache up to a specific message, cache only `tools`, etc.) is not reachable through Mastra's call-site shortcut
+- a future Anthropic API tightening or an AI SDK rewrite can disable the shortcut without an error
+- the instruction-level pattern is the portable form — `providerOptions` placed on the `instructions` object so AI SDK serializes it onto the system block:
+
+```ts
+new Agent({
+  instructions: {
+    role: 'system',
+    content: STABLE_BASE,
+    providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+  },
+  model,
+});
+```
+
+For agents with both static and dynamic system content, use an array of system messages and place the breakpoint on the last static one.
+
+### Memory({ workingMemory: { enabled: true } }) Injects Extra Prefix Content
+
+Enabling working memory adds two things to every `agent.generate(...)` request, on the first turn, without explicit caller code:
+
+1. a second system block whose text starts `WORKING_MEMORY_SYSTEM_INSTRUCTION:` (~2,100 chars)
+2. an `updateWorkingMemory` tool prepended to the `tools` array
+
+Wire shape:
+
+```text
+system[0] = the caller's `instructions` text
+system[1] = "WORKING_MEMORY_SYSTEM_INSTRUCTION:\n..." (Mastra-injected)
+tools     = [updateWorkingMemory, ...the caller's tools]
+messages  = ... (grows between turns; tool_use + tool_result accumulate)
+```
+
+The injected system text and tool definition are byte-stable while no working memory has been written yet. After `updateWorkingMemory` runs, the stored state becomes part of the working-memory system content on subsequent calls. Place the Anthropic breakpoint on the caller's `instructions` system block — before any memory-driven content — so it survives state updates.
+
+### Semantic Recall Position Is Not Documented
+
+`semanticRecall` retrieves past messages by vector search per query. Where the retrieved set lands in `messages[]` is not specified in the public docs. The retrieved content changes per query, so anything after the semantic-recall insertion point is volatile by design. Cache breakpoints placed after semantic recall do not produce reuse — place the breakpoint on the last system block before any memory injection runs.
+
+### Workflow Steps Do Not Share LLM Prefix
+
+`createWorkflow` / `createStep` issue independent LLM calls. There is no shared prompt prefix between two steps that call different agents, and no automatic prefix sharing between sibling steps that call the same agent. Reuse comes only from each individual agent's stable `instructions + tools` across many calls.
+
+### MCP Tools
+
+`MCPClient.listTools()` at agent construction is cache-friendly when the result is frozen for the agent's lifetime. The per-call alternative — `toolsets: await mcp.listToolsets()` passed into `generate()`/`stream()` — fetches tools on every call and invalidates the tools block. In serverless deployments where the `Agent` is reconstructed per request, `listTools()` also runs per request and can return different schemas if the MCP server changed. Tool ordering from `MCPClient.listTools()` is not documented as deterministic — sort by name in the agent definition if cross-deploy stability matters.
+
+### ResponseCache Is Not Prompt Caching
+
+The `ResponseCache` processor skips the model entirely on hit and returns the previous response. It is keyed on `{agentId, scope, model, prompt, stepNumber}`, not on prompt prefix bytes. A `ResponseCache` hit has no `providerMetadata` because no LLM call happened. Do not measure prompt-cache effectiveness over a population that includes `ResponseCache` hits; filter them out first.
+
+## Diagnostics
+
+The SDK rollup at `result.providerMetadata.anthropic.cacheReadInputTokens` is not a reliable per-request value inside Mastra's agent loop. Common mismatches:
+
+- single `generate` that internally made one HTTP call but the rollup reports 0 while raw `cache_read_input_tokens` in the response body is large (telemetry lost in some Memory-enabled paths)
+- single `generate` that internally made multiple HTTP calls and the rollup reports a sum larger than any single wire response (the rollup adds reads across the tool-call → continuation hop)
+
+For accurate per-request numbers, wrap the model provider's `fetch` (see `references/vercel-ai-sdk.md` § Diagnostics) and read raw `usage.cache_read_input_tokens` from each HTTP response body. The SDK rollup is acceptable for "is the cache working at all" sanity checks.
+
+Symptom → first check:
+
+- function-form `instructions` and high cache-write spend, low cache-read: grep the function body for `Date`, `now`, `uuid`, `runtimeContext`, `random`
+- working memory enabled and `cache_read_input_tokens` drops after `updateWorkingMemory` is called for the first time in a thread: confirm the breakpoint sits on the caller's `instructions` system block, not after the working-memory injection point
+- `result.providerMetadata` shows fewer cached tokens than the bill suggests: cross-check against raw HTTP usage; the rollup is unreliable in multi-step `generate`
+
+## Monitoring
+
+Track per agent and per route:
+- `@mastra/core`, `@mastra/memory`, `@mastra/ai-sdk`, `ai`, and `@ai-sdk/<provider>` versions
+- `instructions` shape (string / array / function) — flag function form for review
+- `memory` enabled: `workingMemory`, `semanticRecall`, `lastMessages.windowSize`
+- `tools` source: static, MCP `listTools`, MCP `listToolsets`
+- presence of `ResponseCache` processor and its `scope`
+- per-call wire body capture for the first request in a session: confirm `cache_control` location, system block count, tools count, and tool ordering
+- raw provider `cache_read_input_tokens` / `cache_creation_input_tokens` from the wire, not the SDK rollup
+- ratio of `agent.generate(...)` calls that engaged `ResponseCache` vs hit the model (so prompt-cache metrics are computed over the right denominator)

--- a/audit-prompt-caching/references/vercel-ai-sdk.md
+++ b/audit-prompt-caching/references/vercel-ai-sdk.md
@@ -1,0 +1,199 @@
+# Vercel AI SDK Prefix Cache Reference
+
+## Documentation Freshness
+
+Last reviewed: 2026-05-26.
+
+Verify before exact claims:
+- which API endpoint the `@ai-sdk/openai` factory selects in the installed major version (`openai(model)` vs `openai.chat(model)` vs `openai.responses(model)`)
+- `providerOptions` shape for the installed `@ai-sdk/anthropic`, `@ai-sdk/openai`, `@ai-sdk/amazon-bedrock`, `@ai-sdk/google` versions
+- whether `experimental_providerMetadata` is still accepted, deprecated, or removed
+- telemetry field path on `result.usage` and `result.providerMetadata` for the installed major version
+- `convertToModelMessages` / `convertToCoreMessages` behavior for `providerOptions` carry-over
+- `experimental_prepareStep` and `stopWhen` signatures and the open status of issue #14170
+
+Official sources:
+- AI SDK Core: https://ai-sdk.dev/docs/ai-sdk-core
+- Anthropic provider: https://ai-sdk.dev/providers/ai-sdk-providers/anthropic
+- OpenAI provider: https://ai-sdk.dev/providers/ai-sdk-providers/openai
+- Bedrock provider: https://ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock
+- Google provider: https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai
+- Issue #14170 (prepareStep busts cache): https://github.com/vercel/ai/issues/14170
+- Issue #15185 (tool-result providerOptions dropped pre-v6): https://github.com/vercel/ai/issues/15185
+
+## Stable Mechanics
+
+Vercel AI SDK is a client wrapper, not a model provider. Cache semantics come from the underlying provider; the SDK's contribution is where it places provider-specific directives on the wire and how it surfaces cache telemetry to the caller. Both can change across `ai` and `@ai-sdk/<provider>` major versions; pin the installed versions before reading the rest of this reference.
+
+Provider-cache mechanics for the underlying API live in `references/anthropic.md`, `references/openai.md`, `references/bedrock.md`, and `references/gemini.md`. This reference covers only the wrapper layer.
+
+## Provider Checks
+
+### Detect Vercel AI SDK Before Generic Provider
+
+`@ai-sdk/openai` and `@ai-sdk/anthropic` look like the direct provider SDKs but route through `ai`. The wire body and telemetry fields can differ from the direct-SDK case. Load this reference first, then the provider reference for wire mechanics.
+
+```bash
+rg -n "@ai-sdk/|from ['\"]ai['\"]|providerOptions|experimental_providerMetadata|convertToModelMessages|convertToCoreMessages|experimental_prepareStep|stopWhen|streamText|generateText|generateObject|streamObject" .
+```
+
+Pin the major versions before recommending field names:
+
+```bash
+node -p "require('./node_modules/ai/package.json').version"
+node -p "require('./node_modules/@ai-sdk/anthropic/package.json').version"
+node -p "require('./node_modules/@ai-sdk/openai/package.json').version"
+```
+
+### OpenAI Default Factory Changed Endpoint Between v4 And v5
+
+For identical caller code, the default `openai(modelId)` factory targets different REST endpoints in different majors:
+
+| Stack | Factory used | Endpoint |
+|---|---|---|
+| v4 default | `openai('gpt-4o-mini')` | `POST /v1/chat/completions` |
+| v5 default | `openai('gpt-4o-mini')` | `POST /v1/responses` |
+| explicit | `openai.chat('gpt-4o-mini')` | `POST /v1/chat/completions` |
+| explicit | `openai.responses('gpt-4o-mini')` | `POST /v1/responses` |
+
+OpenAI's prefix-cache lookup on the Responses API does not engage on its own — it requires `prompt_cache_key`. On Chat Completions the lookup is automatic. After a v4 → v5 upgrade without code changes, OpenAI `cached_tokens` typically drops to zero because the default endpoint moved to Responses while `promptCacheKey` was not set.
+
+Audit grep:
+
+```bash
+rg -n "openai\(['\"]|openai\.chat\(|openai\.responses\(|promptCacheKey|promptCacheRetention" .
+```
+
+Safe first action when telemetry shows OpenAI `cached_tokens == 0` after a v5 upgrade: add `providerOptions: { openai: { promptCacheKey: '<route-name>' } }` to the call. Per-user keys destroy cross-user reuse; prefer route- or prompt-family-level keys.
+
+### Anthropic cacheControl Placement Depends On The Field Shape
+
+Where the SDK puts `cache_control` on the wire depends on which surface carries `providerOptions`:
+
+| Source code shape | v4 wire | v5 wire |
+|---|---|---|
+| `system: 'string'`, no `providerOptions` | no `cache_control` | no `cache_control` |
+| `system: 'string'` + top-level `providerOptions.anthropic.cacheControl` | no `cache_control` (silently dropped) | `cache_control` at top level of the request body (not on a block) |
+| `messages: [{ role: 'system', content: '...', providerOptions: { anthropic: { cacheControl: {...} } } }]` | on the system block | on the system block |
+| `messages: [{ role: 'user', content: [{ type: 'text', text, providerOptions: {...} }, ...] }]` | on the text part | on the text part |
+| `tool({ ..., experimental_providerMetadata: { anthropic: { cacheControl: {...} } } })` | no `cache_control` (silently dropped) | n/a |
+| `tool({ ..., providerOptions: { anthropic: { cacheControl: {...} } } })` | n/a in v4 typings | on the tool definition |
+
+The v5 top-level placement for the `system: 'string'` case is not in the public Anthropic API spec. Anthropic currently accepts it. The canonical pattern (`messages[]` with `providerOptions` on the specific block) is the only form portable across SDK versions and across providers. Audit recommendation:
+
+- accept `system: 'string' + cacheControl` only when telemetry on the installed versions confirms it works
+- recommend rewriting to `messages[]` with a system-role message for any load-bearing breakpoint
+
+Audit grep:
+
+```bash
+rg -n "system\s*:\s*['\"\\\\]|providerOptions|experimental_providerMetadata|cacheControl|cache_control" .
+```
+
+### convertToModelMessages Does Not Carry providerOptions
+
+`UIMessage[]` (what `useChat` produces on the client) has no `providerOptions` slot. `convertToModelMessages(messages)` on the server transforms to `ModelMessage[]` but does not invent `providerOptions` that did not exist on the input. Re-attach `cacheControl` on the server after conversion, not in the client component.
+
+### Tool-Result providerOptions Was Dropped Pre-v6
+
+Fixed in `ai@6.x`. On older majors `providerOptions` on a tool-result message is silently absent from the wire. If a codebase caches tool results and `cache_write_tokens` stays zero on tool-result-heavy prompts, upgrade `ai` before further tuning. See https://github.com/vercel/ai/issues/15185.
+
+### experimental_prepareStep Busts The Cache When activeTools Changes
+
+Any `prepareStep` that returns a different `tools` set or `activeTools` on different steps rewrites the cacheable prefix and forces full prefill on the next step. Open at time of review: https://github.com/vercel/ai/issues/14170.
+
+```bash
+rg -n "experimental_prepareStep|prepareStep|activeTools|stopWhen|isStepCount" .
+```
+
+Architectural mitigation only: keep the full tool list constant across steps and rely on the model's selection, or use the underlying provider's allowed-tools mechanism (when exposed by the SDK) instead of mutating `tools`. Sort tools by name regardless.
+
+### 1h TTL Telemetry Has A Per-Bucket Breakdown
+
+`{ type: 'ephemeral', ttl: '1h' }` reaches the Anthropic wire on both v4 and v5. The response carries a per-TTL breakdown alongside the legacy total:
+
+```json
+"usage": {
+  "cache_creation_input_tokens": 2213,
+  "cache_read_input_tokens": 0,
+  "cache_creation": {
+    "ephemeral_5m_input_tokens": 0,
+    "ephemeral_1h_input_tokens": 2213
+  }
+}
+```
+
+Cost dashboards that separate 5m vs 1h write spend must read `cache_creation.ephemeral_{5m,1h}_input_tokens`, not the summed `cache_creation_input_tokens`.
+
+### generateObject Schema Serialization
+
+`generateObject` + Zod produces byte-stable wire payloads across calls when the schema is module-level and unchanged. Risks to watch in code review:
+
+- Zod schemas constructed inside the request handler with inline `.describe()` strings that depend on runtime values
+- per-request additions to `response_format` such as `request_id`, tenant, or timestamps
+- changes to schema field order between calls
+
+If any are present, treat the structured-output schema as a dynamic block in the cacheable prefix.
+
+### streamText / streamObject
+
+`cache_control` is preserved through the streaming path. Cache fields surface after the stream completes; await the promise-shaped accessors:
+
+```ts
+const stream = streamText({ model, messages });
+for await (const _ of stream.textStream) { /* discard or render */ }
+const usage = await stream.usage;
+const providerMetadata = await stream.providerMetadata;
+```
+
+For raw SSE bodies, parse `event: message_delta` / `event: message_stop` chunks to recover `usage` — the response body in network logs is event-stream, not JSON.
+
+## Diagnostics
+
+Pin the SDK surface to read the right field:
+
+```ts
+// v5+ (ai >= 5)
+result.usage.inputTokenDetails?.cacheReadTokens
+result.usage.inputTokenDetails?.cacheWriteTokens
+result.providerMetadata?.anthropic?.cacheReadInputTokens
+result.providerMetadata?.anthropic?.cacheCreationInputTokens
+result.providerMetadata?.openai?.cachedPromptTokens
+
+// v4 (ai 4.x) — deprecated names
+result.usage.cachedInputTokens
+result.providerMetadata?.anthropic?.cacheCreationInputTokens
+```
+
+The v5 `inputTokenDetails` path and the provider-namespaced fields can both be present and equal. Pick one as the source of truth in dashboards; do not double-count.
+
+When the SDK report disagrees with provider raw usage, the raw wire body is authoritative. Capture it by wrapping `fetch`:
+
+```ts
+const logging = (input, init) => {
+  // log JSON.parse(init.body) and the parsed response usage
+  return fetch(input, init);
+};
+const anthropic = createAnthropic({ apiKey, fetch: logging });
+```
+
+This is the fastest way to see whether `cache_control` actually appears in the body and where it landed (top level vs system block vs tool vs content part).
+
+Symptom → first check:
+
+- `cached_tokens == 0` with OpenAI v5 default factory: confirm endpoint is `/v1/responses` and that `promptCacheKey` is set
+- both `cache_creation_input_tokens` and `cache_read_input_tokens` zero on Anthropic: confirm `cache_control` is on the wire at all
+- cache write but no read: directive landed at top level (v5 quirk) but the cached prefix bytes differ from earlier calls, or TTL expired, or a different route served call 2
+- generateObject regression after schema rewrite: compare the serialized JSON Schema in the wire body between two calls
+
+## Monitoring
+
+Track per route family:
+- `ai` and `@ai-sdk/<provider>` package versions and major
+- chosen API factory (`openai(...)`, `openai.chat(...)`, `openai.responses(...)`, equivalents for other providers)
+- presence of `cache_control` / `prompt_cache_key` in the captured wire body
+- wire location of `cache_control` (top level vs system block vs tool vs content part)
+- raw provider `cache_read_input_tokens` / `cache_creation_input_tokens` / `cached_tokens` per request
+- SDK-surface `inputTokenDetails.cacheReadTokens` / `providerMetadata.<p>.cachedPromptTokens` and any divergence from raw
+- ratio of raw cache read tokens to raw input tokens by route
+- `experimental_prepareStep` / `stopWhen` presence and `tools_count` per step


### PR DESCRIPTION
Adds two new wrapper-layer references that the skill currently does not cover, plus the minimum Provider Detection entries needed to route auditors to them.

## What's added

- `references/vercel-ai-sdk.md` — covers where the SDK puts `cache_control` / `prompt_cache_key` on the wire, the v4 → v5 default OpenAI endpoint switch (Chat Completions → Responses) and its impact on automatic caching, `experimental_providerMetadata` drop on tools in v4, `experimental_prepareStep` cache-bust (issue #14170), telemetry field path changes between SDK majors, `generateObject` schema stability, and `streamText` cache behavior.
- `references/mastra.md` — Mastra is layered on Vercel AI SDK; this reference adds the framework-specific concerns: function-form `instructions` re-evaluation, `agent.generate({ providerOptions })` wire-body placement, `workingMemory` injection of an extra system block and `updateWorkingMemory` tool, semantic recall position, MCP tool stability, `ResponseCache` vs prompt cache distinction, and the SDK-rollup telemetry gap inside the agent loop.
- `SKILL.md` — two rows in the Provider Detection table so the skill picks up `@ai-sdk/*` and `@mastra/*` signals and loads these references. Nothing else in `SKILL.md` is touched; wrapper precedence and audit guidance live in the references themselves.

Both references follow the existing house style (Documentation Freshness / Stable Mechanics / Provider Checks / Diagnostics / Monitoring) and avoid restating prompt-cache basics already in `references/anthropic.md`, `references/openai.md`, and `references/agent-tools.md`.

## Verification

All `CONTRIBUTING.md` checks pass on this branch:

- `python3 -m unittest tests/test_prompt_cache_scripts.py` → 53 tests OK
- `python3 audit-prompt-caching/scripts/validate_skill_package.py audit-prompt-caching` → `status: ok`, no errors or warnings
- `python3 audit-prompt-caching/scripts/run_trigger_eval.py audit-prompt-caching` → 76 cases, no errors
- `git diff --check` → clean

Happy to split the two references into separate PRs if that's easier to review.