### PR TITLE
Add mid-conversation system messages to Anthropic reference

### DIFF
--- a/audit-prompt-caching/SKILL.md
+++ b/audit-prompt-caching/SKILL.md
@@ -222,7 +222,7 @@ Search SDK imports, API base URLs, model names, deployment manifests, and config
 | `AzureOpenAI`, `AZURE_OPENAI_ENDPOINT`, `azure.ai.openai`, `api-version`, Azure OpenAI endpoint URLs | Azure OpenAI | `references/azure-openai.md` |
 | `openai`, `responses.create`, `chat.completions`, `prompt_cache_key`, `prompt_cache_retention` | OpenAI | `references/openai.md` |
 | `bedrock-runtime`, `BedrockRuntime`, `boto3.client("bedrock-runtime")`, `client.converse`, `converse_stream`, `InvokeModelCommand`, `ConverseCommand`, `invoke_model`, `cachePoint`, `CacheReadInputTokens`, `CacheWriteInputTokens` | Amazon Bedrock | `references/bedrock.md` |
-| `anthropic`, `messages.create`, `cache_control` | Anthropic | `references/anthropic.md` |
+| `anthropic`, `messages.create`, `cache_control`, `"role": "system"` in `messages` | Anthropic | `references/anthropic.md` |
 | `vllm`, `--enable-prefix-caching`, `vllm bench serve`, `prefix_repetition`, `benchmark_prefix_caching.py`, `AsyncLLMEngine`, `LLM(` | vLLM | `references/vllm.md` |
 | `sglang`, `sglang_router`, `RadixAttention`, `--disable-radix-cache`, `HiCache` | SGLang | `references/sglang.md` |
 | `deepseek`, `api.deepseek.com`, `prompt_cache_hit_tokens` | DeepSeek | `references/deepseek.md` |
@@ -369,6 +369,8 @@ def manage_context(messages, max_tokens):
 ```
 
 For agents: prefer raw history, then compact bulky tool results by preserving paths/IDs/URLs, and use lossy summarization only when compaction is insufficient. If the stable anchor alone exceeds the budget, do not silently drop it; choose a provider-specific strategy, split the route/tool bundle, or fail closed with a clear diagnostic.
+
+On supported Anthropic routes, appending a `{"role": "system"}` message to `messages` is the cache-preserving way to add a new system instruction mid-session instead of editing the top-level `system` field. See `references/anthropic.md` for placement rules and current model availability.
 
 ### AP-6: Mode Switching Or Framework Injection Mutates The Prefix
 

--- a/audit-prompt-caching/references/anthropic.md
+++ b/audit-prompt-caching/references/anthropic.md
@@ -10,12 +10,14 @@ Verify before exact claims:
 - cache write/read pricing, Batch API interactions, and TTL premiums
 - `cache_control` syntax, limits, provider availability, and TTL ordering
 - automatic caching support by surface: Claude API, Azure AI Foundry, Amazon Bedrock, Google Vertex AI, and managed routers
+- which Claude models support mid-conversation `{"role": "system"}` messages — `claude-opus-4-8` only at the time of this reference, likely expanded since
 - tool search / `defer_loading` behavior
 - usage object fields and streaming event fields
 - data retention, ZDR, and cache isolation boundaries
 
 Official sources:
 - Prompt caching: https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+- Mid-conversation system messages: https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages
 - Tool use: https://platform.claude.com/docs/en/build-with-claude/tool-use
 - Tool use with prompt caching: https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-use-with-prompt-caching
 - Pricing: https://www.anthropic.com/pricing
@@ -61,6 +63,22 @@ When combining automatic caching with explicit breakpoints, remember that automa
 Use explicit breakpoints when different sections change at different frequencies, or when the prompt has a stable prefix followed by a dynamic suffix. Place `cache_control` on the last block whose full prefix should remain identical across the requests that should share a cache.
 
 For long growing conversations, add additional breakpoints before they are needed if the active breakpoint can move more than 20 blocks beyond the most recent prior write. A later breakpoint cannot recover an entry that was never written in its lookback window.
+
+### Mid-Conversation System Messages
+
+`{"role": "system"}` entries inside `messages` carry system-level authority without touching the top-level `system` field, so the cached `tools → system → messages` prefix above them stays intact. Editing the top-level `system` field mid-session re-hashes the prefix and invalidates the system block and every cached message after it.
+
+Available at the time of this reference on Claude API and Claude Platform on AWS, `claude-opus-4-8` only; not on Bedrock, Vertex AI, or Microsoft Foundry. No beta header. Recheck the supported model list — it is the most likely thing to have expanded since.
+
+A mid-conversation system message itself becomes part of the stable history on the next turn — the breakpoint can move past it under automatic caching or via an explicit breakpoint on the message. Editing or removing one already sent invalidates the cache from that point; append a new one instead of rewriting.
+
+Audit grep:
+
+```bash
+rg -n '"role"\s*:\s*"system"' .
+```
+
+For every match inside `messages[]`, confirm placement and a supported Anthropic surface. Treat top-level `system` edits between turns as a cache-cost finding when a mid-conversation system message would have preserved the prefix on a supported route.
 
 ### Tool Cascade
 


### PR DESCRIPTION
Anthropic shipped `{"role": "system"}` entries inside `messages[]` as a cache-preserving alternative to editing the top-level `system` field mid-session. Docs: https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages

In `references/anthropic.md` I added a new Provider Check section with cache mechanics, availability (Claude API + AWS, `claude-opus-4-8` only at the time of writing, with a note to recheck the model list since it'll likely expand), lifecycle on the next turn, and an audit grep. Plus a bullet in Documentation Freshness and the official source link.

In `SKILL.md` I added `"role": "system"` to the Anthropic row in Provider Detection and a short line in AP-5 pointing at the new section as the cache-preserving alternative on supported Anthropic routes.

All CONTRIBUTING checks pass.