### PR TITLE
docs(agent-tools): harness restarts reset an auto-generated cache key

### DIFF
--- a/audit-prompt-caching/references/agent-tools.md
+++ b/audit-prompt-caching/references/agent-tools.md
@@ -24,11 +24,21 @@ restarted agent loop can still start a fresh cache lineage.
 
 SDKs that generate a `prompt_cache_key` for the caller resolve it from a grouping hierarchy and
 only fall back to a per-run value when no grouping handle is supplied. In the OpenAI Agents SDK
-(Python), `agents/run_internal/prompt_cache_key.py` and `run_grouping.py` resolve, in order:
-`conversation_id`, `session.session_id`, `group_id`, then a generated per-run UUID.
+(Python), the resolver in `agents/run_internal/prompt_cache_key.py` and `run_grouping.py` —
+private SDK internals, not a public API, and version-sensitive — resolves, in order:
+`conversation_id`, `session.session_id`, `RunConfig.group_id`, then a generated per-run UUID.
 `PromptCacheKeyResolver` also persists `_generated_prompt_cache_key` on `RunState`, so a resume
-from `RunState` reuses the key, and it opts out entirely when the request already forwards a
-user-supplied key.
+from `RunState` reuses the key.
+
+Two gates decide whether an SDK-generated key exists at all. Neither is affected by
+auto-generated key churn, so check both before diagnosing restarts:
+
+- **Model opt-in.** A key is generated only for models exposing a truthy
+  `_supports_default_prompt_cache_key` (again a private, version-sensitive SDK attribute). A
+  custom or third-party model that does not opt in sends no generated key.
+- **Caller opt-out.** If `ModelSettings.extra_args` or `ModelSettings.extra_body` already carries
+  a `prompt_cache_key`, the resolver forwards that value unchanged and generates nothing. A
+  caller-supplied key is stable by construction.
 
 So the boundary is not "every `Runner.run()` mints a new key". It is a **fresh, ungrouped**
 invocation — a new run carrying no reused `conversation_id`, session, `group_id`, or `RunState`.
@@ -43,8 +53,10 @@ Affected:
 
 Not affected:
 
-- re-invocations that share a `conversation_id`, `session.session_id`, or `group_id`
+- re-invocations that share a `conversation_id`, `session.session_id`, or `RunConfig.group_id`
 - resume from a persisted `RunState`
+- models that do not opt into the SDK's default prompt cache key (no generated key is sent)
+- runs that already pass a caller-supplied `prompt_cache_key` through `ModelSettings`
 
 Grouping and fallback behavior here are SDK-internal, not a provider contract. Verify them against
 the SDK version actually in use before relying on either branch.
@@ -60,26 +72,36 @@ does:
 
 ```text
 if effective prompt_cache_key changes at each loop re-invocation:
-    count(requests with cached_tokens == 0) == count(loop re-invocations) + 1
+    count(requests with cached_tokens == 0) ~= count(loop re-invocations) + 1
 ```
 
-The `+ 1` is the initial write. An exact match across runs of different lengths is then strong
-evidence that key lineage, not prefix drift, is the cause — prefix drift produces zero-cache
-requests that do not line up with restart counts, and it also shows up on runs with zero restarts.
-If the key is stable across restarts and zero-cache requests still track them, look elsewhere
-(prefix drift, retention, routing).
+The `+ 1` is the initial write. This is an observed diagnostic correlation, not an invariant. A
+changed `prompt_cache_key` changes routing locality; it does not guarantee a miss, and a stable
+key does not guarantee a hit. Expect the count to run high wherever another miss source is active:
+cache TTL or retention expiry between requests, eviction under memory pressure, prefix drift from
+tool or system-prompt edits, or hot-key locality overflow spreading traffic across replicas (see
+`openai.md`). Near-equality across runs of different lengths is still strong evidence that key
+lineage, not prefix drift, dominates — prefix drift produces zero-cache requests that do not track
+restart counts, and it also shows up on runs with zero restarts. If the key is stable across
+restarts and zero-cache requests still track them, look elsewhere (prefix drift, retention,
+routing).
 
 Observed on a long-running document-editing agent (~100 model calls per run, ~130k-token context)
 whose restarts did change the effective key: zero-cache requests tracked restarts exactly across
 twenty runs — 29/28, 25/24, 8/7 — and runs with no restarts showed 1 zero-cache request in 100, a
-99% hit rate on the request-count metric used above. Cost tracked the same axis: 24 restarts cost
+99% hit rate on the request-count metric used above. Exact agreement in that dataset is a reported
+observation from one workload, not a rule to expect everywhere. Cost tracked the same axis: 24 restarts cost
 2.8x a 7-restart run on identical work.
 
 ### Checks
 
-- Log the effective `prompt_cache_key` per request, not only per run, and diff it across restarts.
+- Log a keyed hash of the effective `prompt_cache_key` per request, not only per run, and diff the
+  hashes across restarts. The diagnostic needs equality only, so use HMAC-SHA256 under a
+  service-held key — never log the raw value. Generated keys are derived from conversation,
+  session, tenant, or user identifiers, and caller-supplied keys often are too; do not log raw
+  session tokens, IDs, or user-derived key values (see `observability.md`).
 - Log which grouping handle produced it: reused conversation, session, group id, `RunState`, or a
-  per-run fallback.
+  per-run fallback. Log the handle kind, not its raw value.
 - Correlate zero-cache requests with harness events (guardrail recovery, restart, resume), not only
   with prompt or tool changes.
 - Treat a runner re-invocation as a cache boundary only where the effective key is observed to
@@ -87,8 +109,22 @@ twenty runs — 29/28, 25/24, 8/7 — and runs with no restarts showed 1 zero-ca
 
 ### Fix
 
-Reuse the grouping the SDK already offers: carry a stable `conversation_id`, `session`, or
-`group_id` across continuations, recoveries and restarts, or resume from the persisted `RunState`.
+Reuse a grouping handle that spans the logical session — but match it to how the run already
+manages history. Only one of the three handles is history-neutral:
+
+- **`RunConfig.group_id`** is the handle for client-managed `to_input_list()` continuation loops.
+  It is a trace-grouping id that links runs; it changes key resolution without changing where
+  history comes from.
+- **`session`** — reuse only on runs that are already session-managed. Do not add a session on top
+  of a loop that replays `to_input_list()` history; the SDK would prepend stored history to
+  history you already resent.
+- **`conversation_id`** — reuse only on runs that are already server-managed, passing just the new
+  turn. Do not combine it with replaying full `to_input_list()` history.
+- Session persistence cannot be combined with `conversation_id`, `previous_response_id`, or
+  `auto_previous_response_id` in the same run; pick one persistence strategy per call.
+- A resume from a persisted `RunState` already carries the generated key, so it needs no extra
+  handle.
+
 Supply your own key only when no such handle spans the logical session.
 
 Pick granularity deliberately: one key per session of one work item. A single route-wide constant

--- a/audit-prompt-caching/references/agent-tools.md
+++ b/audit-prompt-caching/references/agent-tools.md
@@ -17,58 +17,79 @@ Agent prompts often grow append-only, which is cache-friendly, but tool lists, m
 - Compact bulky tool results before summarizing early history; preserve paths, IDs, URLs, and small structured facts.
 - Treat MCP registry changes as schema changes. Freeze or version tool definitions for a session.
 
-## Harness Restarts Reset an Auto-Generated Cache Key
+## Fresh Ungrouped Restarts Reset an Auto-Generated Cache Key
 
-A distinct failure mode from tool-list churn: the prompt prefix is perfectly stable, yet every
-harness-level restart of the agent loop starts a fresh cache lineage.
+A distinct failure mode from tool-list churn: the prompt prefix is perfectly stable, yet a
+restarted agent loop can still start a fresh cache lineage.
 
-SDKs that generate a `prompt_cache_key` for the caller typically scope that key to **one run
-invocation**, not to the logical session. The OpenAI Agents SDK (Python) states this directly in
-`agents/run_internal/prompt_cache_key.py`: `PromptCacheKeyResolver` "provides one generated prompt
-cache key for a runner invocation" and opts out only when the request already forwards a
+SDKs that generate a `prompt_cache_key` for the caller resolve it from a grouping hierarchy and
+only fall back to a per-run value when no grouping handle is supplied. In the OpenAI Agents SDK
+(Python), `agents/run_internal/prompt_cache_key.py` and `run_grouping.py` resolve, in order:
+`conversation_id`, `session.session_id`, `group_id`, then a generated per-run UUID.
+`PromptCacheKeyResolver` also persists `_generated_prompt_cache_key` on `RunState`, so a resume
+from `RunState` reuses the key, and it opts out entirely when the request already forwards a
 user-supplied key.
 
-Any harness that re-invokes the runner therefore mints a new key. Common causes:
+So the boundary is not "every `Runner.run()` mints a new key". It is a **fresh, ungrouped**
+invocation — a new run carrying no reused `conversation_id`, session, `group_id`, or `RunState`.
 
-- re-entering the loop after a recoverable guardrail or validation failure
-- restarting the agent to break a repeated-tool-failure loop
-- continuation loops that call the runner again with `to_input_list()`
-- resume-after-pause flows that rebuild the run
+Affected:
 
-Each re-invocation re-writes the whole accumulated context. On GPT-5.6 and later, where cache
-writes bill at 1.25x the uncached input rate, that is a premium re-write of the full conversation,
-not a free miss.
+- continuation loops that call the runner again with `to_input_list()` and no reused
+  conversation, session, or group id
+- guardrail or validation recovery that rebuilds an ungrouped run instead of continuing the
+  grouped one
+- restarting the agent to break a repeated-tool-failure loop under the same condition
+
+Not affected:
+
+- re-invocations that share a `conversation_id`, `session.session_id`, or `group_id`
+- resume from a persisted `RunState`
+
+Grouping and fallback behavior here are SDK-internal, not a provider contract. Verify them against
+the SDK version actually in use before relying on either branch.
+
+Each ungrouped re-invocation re-writes the whole accumulated context. On GPT-5.6 and later, where
+cache writes bill at 1.25x the uncached input rate, that is a premium re-write of the full
+conversation, not a free miss.
 
 ### Diagnostic signature
 
-Count requests whose cache-read field is zero and compare with the number of harness restarts in
-the same run:
+First confirm the effective `prompt_cache_key` actually changes across the restarts. Only when it
+does:
 
 ```text
-count(requests with cached_tokens == 0) == count(loop re-invocations) + 1
+if effective prompt_cache_key changes at each loop re-invocation:
+    count(requests with cached_tokens == 0) == count(loop re-invocations) + 1
 ```
 
-The `+ 1` is the initial write. An exact match across runs of different lengths is strong evidence
-that key lineage, not prefix drift, is the cause — prefix drift produces misses that do not line up
-with restart counts, and it also shows up on runs with zero restarts.
+The `+ 1` is the initial write. An exact match across runs of different lengths is then strong
+evidence that key lineage, not prefix drift, is the cause — prefix drift produces zero-cache
+requests that do not line up with restart counts, and it also shows up on runs with zero restarts.
+If the key is stable across restarts and zero-cache requests still track them, look elsewhere
+(prefix drift, retention, routing).
 
-Observed on a long-running document-editing agent (~100 model calls per run, ~130k-token context):
-misses tracked restarts exactly across twenty runs — 29/28, 25/24, 8/7 — and runs with no restarts
-showed 1 miss in 100 requests, a 98.6% hit rate. Cost tracked the same axis: 24 restarts cost 2.8x
-a 7-restart run on identical work.
+Observed on a long-running document-editing agent (~100 model calls per run, ~130k-token context)
+whose restarts did change the effective key: zero-cache requests tracked restarts exactly across
+twenty runs — 29/28, 25/24, 8/7 — and runs with no restarts showed 1 zero-cache request in 100, a
+99% hit rate on the request-count metric used above. Cost tracked the same axis: 24 restarts cost
+2.8x a 7-restart run on identical work.
 
 ### Checks
 
 - Log the effective `prompt_cache_key` per request, not only per run, and diff it across restarts.
+- Log which grouping handle produced it: reused conversation, session, group id, `RunState`, or a
+  per-run fallback.
 - Correlate zero-cache requests with harness events (guardrail recovery, restart, resume), not only
   with prompt or tool changes.
-- If the key is auto-generated, treat every runner re-invocation as a cache boundary until proven
-  otherwise.
+- Treat a runner re-invocation as a cache boundary only where the effective key is observed to
+  change.
 
 ### Fix
 
-Supply your own key and scope it to the logical session rather than the invocation, so
-continuations, recoveries and restarts share one cache lineage.
+Reuse the grouping the SDK already offers: carry a stable `conversation_id`, `session`, or
+`group_id` across continuations, recoveries and restarts, or resume from the persisted `RunState`.
+Supply your own key only when no such handle spans the logical session.
 
 Pick granularity deliberately: one key per session of one work item. A single route-wide constant
 concentrates traffic on one key, and OpenAI documents an approximate 15 requests per minute

--- a/audit-prompt-caching/references/agent-tools.md
+++ b/audit-prompt-caching/references/agent-tools.md
@@ -17,6 +17,64 @@ Agent prompts often grow append-only, which is cache-friendly, but tool lists, m
 - Compact bulky tool results before summarizing early history; preserve paths, IDs, URLs, and small structured facts.
 - Treat MCP registry changes as schema changes. Freeze or version tool definitions for a session.
 
+## Harness Restarts Reset an Auto-Generated Cache Key
+
+A distinct failure mode from tool-list churn: the prompt prefix is perfectly stable, yet every
+harness-level restart of the agent loop starts a fresh cache lineage.
+
+SDKs that generate a `prompt_cache_key` for the caller typically scope that key to **one run
+invocation**, not to the logical session. The OpenAI Agents SDK (Python) states this directly in
+`agents/run_internal/prompt_cache_key.py`: `PromptCacheKeyResolver` "provides one generated prompt
+cache key for a runner invocation" and opts out only when the request already forwards a
+user-supplied key.
+
+Any harness that re-invokes the runner therefore mints a new key. Common causes:
+
+- re-entering the loop after a recoverable guardrail or validation failure
+- restarting the agent to break a repeated-tool-failure loop
+- continuation loops that call the runner again with `to_input_list()`
+- resume-after-pause flows that rebuild the run
+
+Each re-invocation re-writes the whole accumulated context. On GPT-5.6 and later, where cache
+writes bill at 1.25x the uncached input rate, that is a premium re-write of the full conversation,
+not a free miss.
+
+### Diagnostic signature
+
+Count requests whose cache-read field is zero and compare with the number of harness restarts in
+the same run:
+
+```text
+count(requests with cached_tokens == 0) == count(loop re-invocations) + 1
+```
+
+The `+ 1` is the initial write. An exact match across runs of different lengths is strong evidence
+that key lineage, not prefix drift, is the cause — prefix drift produces misses that do not line up
+with restart counts, and it also shows up on runs with zero restarts.
+
+Observed on a long-running document-editing agent (~100 model calls per run, ~130k-token context):
+misses tracked restarts exactly across twenty runs — 29/28, 25/24, 8/7 — and runs with no restarts
+showed 1 miss in 100 requests, a 98.6% hit rate. Cost tracked the same axis: 24 restarts cost 2.8x
+a 7-restart run on identical work.
+
+### Checks
+
+- Log the effective `prompt_cache_key` per request, not only per run, and diff it across restarts.
+- Correlate zero-cache requests with harness events (guardrail recovery, restart, resume), not only
+  with prompt or tool changes.
+- If the key is auto-generated, treat every runner re-invocation as a cache boundary until proven
+  otherwise.
+
+### Fix
+
+Supply your own key and scope it to the logical session rather than the invocation, so
+continuations, recoveries and restarts share one cache lineage.
+
+Pick granularity deliberately: one key per session of one work item. A single route-wide constant
+concentrates traffic on one key, and OpenAI documents an approximate 15 requests per minute
+envelope per key before requests begin to miss (see `openai.md`). A per-request key defeats the
+purpose entirely.
+
 ## Report
 
 Classify findings as confirmed, hypotheses, or not applicable. Severity depends on hotness, trajectory length, prefix size, and measured cache/TTFT impact.


### PR DESCRIPTION
Adds a failure mode to `references/agent-tools.md` that the existing guidance does not cover. That reference treats agent cache loss as prefix churn — tool lists, mode instructions, memory blocks, compaction. This one is different: the prefix is perfectly stable and the cache is still lost.

Documentation only, no script behaviour changed.

> Split out of an earlier combined branch. The GPT-5.6 provider-contract corrections are now separate: #15.

## Mechanism

SDKs that generate a `prompt_cache_key` for the caller scope it to **one run invocation**, not the logical session. The OpenAI Agents SDK (Python) states it directly in `agents/run_internal/prompt_cache_key.py` — `PromptCacheKeyResolver` "provides one generated prompt cache key for a runner invocation", opting out only when the request already forwards a user-supplied key.

So any harness that re-invokes the runner starts a fresh cache lineage: guardrail-failure recovery, restarts that break a repeated tool-failure loop, continuation loops calling the runner again with `to_input_list()`, resume-after-pause flows. Each one re-writes the whole accumulated context — and on GPT-5.6 and later that bills at 1.25x the uncached input rate, so it is a premium re-write rather than a free miss.

## Diagnostic signature

The section's main practical contribution:

```
count(requests with cached_tokens == 0) == count(loop re-invocations) + 1
```

The `+1` is the initial write. An exact match separates this cause from prefix drift, which does not line up with restart counts and also appears on restart-free runs.

## Evidence

A long-running document-editing agent, ~100 model calls per run against a ~130k-token context, twenty-plus runs:

- misses tracked restarts exactly — 29/28, 25/24, 8/7, no exceptions
- restart-free runs: 1 miss in 100 requests, 98.6% hit rate
- cost tracked the same axis: a 24-restart run cost 2.8x a 7-restart run on identical work

## Fix documented

A session-scoped key rather than an invocation-scoped one, with the granularity trade-off spelled out — the section points at the ~15 rpm per-key envelope already in `openai.md` so readers do not solve this by collapsing onto one route-wide constant.

## Verification

```
python3 -m unittest tests/test_prompt_cache_scripts.py                                 # 73 tests, OK
python3 audit-prompt-caching/scripts/validate_skill_package.py audit-prompt-caching     # no errors, no warnings
python3 audit-prompt-caching/scripts/run_trigger_eval.py audit-prompt-caching           # no errors
git diff --check                                                                        # clean
```

`__pycache__` removed before committing.

Happy to move the diagnostic signature into `references/observability.md` if you would rather keep `agent-tools.md` to checks only.