### PR TITLE
Add evidence-grade prompt cache audit reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ python3 audit-prompt-caching/scripts/render_audit_report.py \
   --usage-log path/to/usage.jsonl \
   --provider openai \
   --engine "Responses API" \
+  --cache-plane gateway_response \
+  --cache-plane provider_prompt \
+  --evidence-quality warning \
+  --usage-accounting warning \
+  --prefix-stability fail \
   --finding "src/llm/request.py:42 | high | openai | dynamic timestamp in system prompt | timestamp changes the cacheable prefix on every call | move volatile metadata after the stable prefix | compare rendered request bytes across repeated calls"
 python3 audit-prompt-caching/scripts/validate_skill_package.py audit-prompt-caching
 python3 audit-prompt-caching/scripts/run_trigger_eval.py audit-prompt-caching
@@ -203,6 +208,14 @@ python3 audit-prompt-caching/scripts/run_trigger_eval.py audit-prompt-caching
 
 `layout_linter.py` accepts rendered Chat-style `messages` payloads and
 Responses-style `input` payloads.
+
+`render_audit_report.py` takes `--cache-plane` once per plane in scope
+(`gateway_response`, `provider_prompt`, `engine_kv`, `external_kv`,
+`semantic_response`) and one status per Cache Clinic dimension, such as
+`--evidence-quality` or `--usage-accounting`. Unset dimensions stay `unknown`,
+and the report emits no aggregate score across them. When the normalized usage
+denominator is `ambiguous` or `invalid`, the rendered cache hit ratio is
+qualified as non-decision-grade and cannot support a savings claim.
 
 `prefix_stability_check.py` compares raw bytes by default so JSON key-order drift is visible. Use `--canonical-json` only when sorted-key normalization is intentional.
 

--- a/README.md
+++ b/README.md
@@ -214,8 +214,15 @@ Responses-style `input` payloads.
 `semantic_response`) and one status per Cache Clinic dimension, such as
 `--evidence-quality` or `--usage-accounting`. Unset dimensions stay `unknown`,
 and the report emits no aggregate score across them. When the normalized usage
-denominator is `ambiguous` or `invalid`, the rendered cache hit ratio is
-qualified as non-decision-grade and cannot support a savings claim.
+denominator is `ambiguous` or `invalid`, the rendered cache hit ratio and both
+cost lines (`Cost impact:` and the priced-scenario `Assessment:`) are qualified
+as non-decision-grade and cannot support a savings claim.
+
+`render_audit_report.py --accounting-mode inclusive|additive` resolves wrapper
+usage logs whose cache-token accounting is only known externally, the same way
+`analyze_usage_logs.py --accounting-mode` does. It cannot rescue an inclusive
+contradiction: a denominator that stays `invalid` still rejects
+`--usage-accounting pass`.
 
 `prefix_stability_check.py` compares raw bytes by default so JSON key-order drift is visible. Use `--canonical-json` only when sorted-key normalization is intentional.
 

--- a/audit-prompt-caching/SKILL.md
+++ b/audit-prompt-caching/SKILL.md
@@ -2,41 +2,37 @@
 name: audit-prompt-caching
 description: >
   Use whenever the user mentions LLM prompt/prefix cache misses, cached_tokens=0,
-  cache_read_input_tokens/cache_creation_input_tokens, cache_write_tokens,
-  total_cached_tokens, prompt_cache_key, session_id, previous_interaction_id,
-  prompt_cache_key, prompt_cache_options, prompt_cache_breakpoint,
-  cache_control/cachePoint, TTFT/prefill latency, KV reuse, LLM cost or speed
-  regressed on repeated long prompts, or speeding up agents through cache
-  stability. Use for LLM request shape changes: prompt text/order/builders,
-  tools, schemas, response_format, model/router, agent loops, or compaction.
-  Not for generic prompt writing/RAG, token counts, or non-LLM perf.
+  cache_read_input_tokens, cache_write_tokens, prompt_cache_key,
+  prompt_cache_options, cache_control/cachePoint, TTFT/prefill, KV reuse,
+  LLM cost or speed regressed on repeated long prompts, or speeding up agents
+  through cache stability. Use for LLM request shape changes:
+  prompt text/order/builders, tools, schemas, response_format, model/router,
+  agent loops, compaction. Not for generic prompt writing/RAG, token counts,
+  or non-LLM perf.
 ---
 
 # Prompt Cache Audit
 
 Diagnose LLM prompt/prefix cache misses as request-path engineering problems:
-stable reusable prefixes, provider telemetry, cache-aware routing, and cache
-entries that live long enough to be reused. Caching is worth changing only when
-the prefix is stable, long enough, repeated, measurable, and safe.
-
-Do not add cache controls, cache keys, cache salts, provider pins, routing hints,
-or broader cache sharing until the applicability, telemetry, and trust-boundary
-checks justify them.
+stable reusable prefixes, provider telemetry, cache-aware routing, and entries
+that live long enough to be reused. Caching is worth changing only when the
+prefix is stable, long enough, repeated, measurable, and safe. Do not add cache
+controls, keys, salts, provider pins, routing hints, or broader cache sharing
+until the applicability, telemetry, and trust-boundary checks justify them.
 
 ## When to use
 
 Use this skill for LLM calls where repeated prompt prefixes may affect cost,
-TTFT, prefill latency, or self-hosted KV reuse.
+TTFT, prefill latency, or self-hosted KV reuse. Typical triggers:
 
-Typical triggers:
-- `cached_tokens=0`, `cache_read_input_tokens=0`, `cache_write_tokens`, cache writes without reads, or unclear provider usage fields.
-- GPT-5.6 `prompt_cache_options`, `prompt_cache_breakpoint`, paid-write behavior, or migration from `prompt_cache_retention`.
-- Cache hit rate, TTFT, prefill latency, or input-token cost changed.
+- `cached_tokens=0`, `cache_read_input_tokens=0`, `cache_write_tokens`, writes without reads, or unclear provider usage fields.
+- GPT-5.6 `prompt_cache_options`, `prompt_cache_breakpoint`, paid writes, or migration from `prompt_cache_retention`.
+- Cache hit rate, TTFT, prefill latency, or input-token cost changed, or a reported hit rate is not trusted.
 - LLM cost or speed regressed around repeated long prompts, shared static context, long-context agents, or tool-heavy loops.
 - LLM request shape changed where repeated long prompts, TTFT, cached-token telemetry, or LLM cost matter.
 - Prompt text, message order, request builders, tools, schemas, `response_format`, provider API surface, model/router settings, agent loop structure, or context compaction changed.
 - The route uses long system prompts, tool catalogs, schemas, static documents, few-shot examples, repeated RAG/CAG context, or provider cache APIs.
-- vLLM/SGLang/self-hosted deployments have multi-replica routing, KV pressure, tokenizer/chat-template drift, cache salts, or APC benchmark workflows such as `vllm bench serve`, `prefix_repetition`, or `benchmark_prefix_caching.py`.
+- vLLM/SGLang/self-hosted deployments have multi-replica routing, KV pressure, tokenizer/chat-template drift, cache salts, or APC benchmarks such as `vllm bench serve`, `prefix_repetition`, or `benchmark_prefix_caching.py`.
 
 ## When not to use
 
@@ -48,76 +44,101 @@ Do not use this skill for:
 - non-LLM frontend/backend performance or non-inference Kubernetes routing
 - speculative savings claims without usage data or explicitly stated assumptions
 
-## Modes
+Modes: code audit (repository available), advisory (no codebase, ask only the
+missing diagnostic questions), agent audit (tools, MCP, loops, compaction), and
+deployment audit (vLLM/SGLang, Kubernetes, gateways, replicas).
 
-- **Code audit**: inspect prompt construction, tool/schema serialization, history management, provider SDK calls, routing, and engine config. Propose focused diffs and verify them.
-- **Advisory**: when no codebase is available, ask only the missing diagnostic questions and give provider-checked recommendations.
-- **Agent audit**: when tools, MCP, agent loops, compaction, or multi-step trajectories are present, run the agent-specific checks.
-- **Deployment audit**: for vLLM/SGLang, Kubernetes, Docker Compose, gateways, or multiple inference replicas, inspect routing locality and KV capacity as first-class causes.
+## Cache Plane Gate
 
-## Default Project Audit Workflow
+State which cache planes are in scope before diagnosing;
+several planes at once is normal, and each needs its own evidence:
 
-When a repository is available, start with code and config:
+- `gateway_response`: response reuse at a gateway or proxy.
+- `provider_prompt`: provider-managed prompt/prefix caching in usage telemetry.
+- `engine_kv`: attention KV reuse inside a self-hosted engine.
+- `external_kv`: KV blocks persisted or moved outside the serving process.
+- `semantic_response`: similarity-based reuse of a prior response.
 
-1. Scan for provider calls, cache controls, routing hints, prompt builders, tool/schema registries, and self-hosted engine signals. Use `scripts/extract_llm_calls.py` when deterministic scanning is useful.
-2. Inspect prompt rendering, system/developer messages, tool ordering, structured-output schemas, history management, compaction, and SDK parameters.
-3. Inspect environment defaults, feature flags, gateway/router settings, Docker Compose, Kubernetes, Helm, vLLM/SGLang flags, and replica topology.
-4. Load only the relevant provider and scenario references.
-5. Ask for usage logs, rendered payload pairs, traces, or billing exports only when telemetry is needed to confirm a finding, compare prefixes, calculate ROI, or correlate incidents.
+Do not infer a plane from provider or model names, routes, or usage fields, and
+do not merge planes: a gateway response-cache hit is not provider prefix reuse.
+Pass every in-scope plane to `render_audit_report.py --cache-plane` and name the
+affected plane in findings.
 
-Bundled fixtures are examples and regression data. Users do not need to convert
-production data into fixture layout; scripts accept normal JSON, JSONL, CSV
-usage logs, and JSON request payloads.
+## Usage Evidence Contract
+
+Before treating a hit rate as decision-grade, read the normalized event fields
+from `analyze_usage_logs.py --jsonl-normalized`: `schema_version`,
+`source_fields` (which raw field produced each canonical value),
+`accounting_semantics` (`inclusive`, `additive`, `ambiguous`),
+`denominator_status`, and `warnings`.
+
+- `valid`: the ratio is usable evidence.
+- `ambiguous`: wrapper semantics unresolved or no measured input; call the ratio
+  non-decision-grade and make no savings claim.
+- `invalid`: an adapter invariant is contradicted; fix accounting first.
+
+Aggregates take the worst status (`invalid > ambiguous > valid`).
+Do not build a second normalizer or hand-compute a ratio around this
+contract; extend the existing adapter. Paths: `references/observability.md`.
+
+## Cache Clinic Summary
+
+Report `applicability`, `evidence_quality`, `prefix_stability`,
+`usage_accounting`, `routing_locality`, `economics`, and `isolation`, each with
+exactly one status of `pass/warning/fail/unknown/not_applicable`.
+Leave every unproven dimension `unknown` instead of dropping it, and
+never aggregate them into a score, rank, or grade. An ambiguous or invalid
+denominator is never `usage_accounting: pass`. See `references/report-template.md`.
+
+## Evidence Boundaries
+
+A stable-prefix plan needs an observed rendered payload or an identified
+request-construction boundary. Separate stable instructions and tools, bounded
+semi-stable context, and request-specific history and user input. Describe
+ordering as an observed application payload property, never as a
+universal provider-internal serialization order without cited provider evidence.
+
+Isolation review is passive and evidence-based: cache-key scope, tenant and
+credential boundaries, and redaction risks visible in config or traces. Active
+cross-tenant probes need separate authorization and are out of scope.
 
 ## Project Context Gate
 
 Before assigning severity or recommending project changes, review hot paths, repeat cadence, prompt families, and cache applicability.
 
-1. Map prompt families, request builders, model/provider routes, agent loops, deployment paths, and usage frequency.
-2. Separate hot repeated paths from rare jobs, one-off prompts, admin flows, experiments, and prompt families with no shareable stable prefix.
-3. Mark each finding as applicable, conditionally applicable, or not applicable to the reviewed path.
-4. Ask for telemetry only after code/config context shows what evidence is missing.
+Map prompt families, request builders, model/provider routes, agent loops, deployment paths, and usage frequency. Separate hot repeated paths from rare jobs, one-off prompts, admin flows, experiments, and families with no shareable stable prefix. Mark each finding applicable, conditionally applicable, or not applicable to the reviewed path, and ask for telemetry only after code/config context shows what evidence is missing.
 
-If a route is rare, short, mostly unique, output/tool-latency dominated, privacy-isolated, or has no stable long prefix, say prompt caching is not the right lever for that route and remove generic cache warnings from actionable findings.
+If a route is rare, short, mostly unique, output/tool-latency dominated, privacy-isolated, or has no stable long prefix, say prompt caching is not the right lever there and drop generic cache warnings from actionable findings.
 
 ## Applicability Gate
 
 Before recommending prompt-cache changes, check:
 
-1. **Reusable prefix**: Is the static or semi-static prefix above the provider/model threshold or large enough to matter for self-hosted KV reuse?
-2. **Repeat cadence**: Is the same prefix reused often enough before expiry or eviction?
-3. **Exact stability**: Are tools, schemas, instructions, examples, media, documents, and early messages byte/token stable across target requests?
-4. **Telemetry**: Are cache read/write fields, input/output tokens, TTFT/prefill timing, route/model, and prompt version available?
-5. **Cost shape**: Is input prefill/input-token cost meaningful, or do output tokens, decode time, and tools dominate?
-6. **Safety boundary**: Would broader reuse violate tenant, privacy, data residency, ZDR, or side-channel requirements?
+1. **Reusable prefix**: is the static or semi-static prefix above the provider/model threshold, or large enough for self-hosted KV reuse?
+2. **Repeat cadence**: is the same prefix reused often enough before expiry or eviction?
+3. **Exact stability**: are tools, schemas, instructions, examples, media, documents, and early messages byte/token stable across target requests?
+4. **Telemetry**: are cache read/write fields, input/output tokens, TTFT/prefill timing, route/model, and prompt version available?
+5. **Cost shape**: is input prefill cost meaningful, or do output tokens, decode time, and tools dominate?
+6. **Safety boundary**: would broader reuse violate tenant, privacy, data residency, ZDR, or side-channel requirements?
 
 If the gate fails, report why caching is not the right lever yet and recommend measurement, prompt restructuring, routing fixes, or a different optimization.
 
 ## Language Match Rule
 
-Answer in the user's language by default. Preserve provider/API field names exactly, such as `cached_tokens`, `cache_write_tokens`, `prompt_cache_options`, `prompt_cache_breakpoint`, `cache_control`, `cachePoint`, `TTFT`, `prompt_cache_key`, and `response_format`, but explain them in the user's language.
+Answer in the user's language by default. Preserve provider/API field names exactly, such as `cached_tokens`, `cache_write_tokens`, `prompt_cache_options`, `prompt_cache_breakpoint`, `cache_control`, `cachePoint`, `TTFT`, and `prompt_cache_key`, but explain them in the user's language.
 
 ## Agent-First Output Contracts
 
 Pick the smallest contract that answers the request:
 
-- **Quick triage**: provider/engine guess, most likely cache blocker, evidence needed next, and one safe next command or artifact request.
+- **Quick triage**: provider/engine guess, planes in scope, likeliest blocker, evidence needed next, one safe next command.
 - **Code audit findings**: decision summary first, then file-line findings, clean checks, and verification commands.
-- **Provider migration risk**: compare cache semantics, usage fields, prefix layout risk, routing risk, and cost assumptions before recommending edits.
-- **Agent loop audit**: inspect stable tools, early messages, per-step prefix hashes, cache fields, output tokens, and compaction events.
-- **Deployment audit**: treat routing locality and KV budget as first-class causes for vLLM, SGLang, Kubernetes, Docker Compose, gateways, autoscaling, or multi-replica inference.
-- **Not worth caching**: use when the Applicability Gate fails or evidence shows output decode, external tools, rate limits, or privacy isolation dominate. State what should change instead and what evidence would reopen prompt-cache work.
+- **Provider migration risk**: compare cache semantics, usage fields, prefix layout, routing, and cost assumptions before recommending edits.
+- **Agent loop audit**: stable tools, early messages, per-step prefix hashes, cache fields, output tokens, compaction events.
+- **Deployment audit**: routing locality and KV budget as first-class causes for vLLM, SGLang, Kubernetes, gateways, autoscaling, or multi-replica inference.
+- **Not worth caching**: when the Applicability Gate fails or output decode, external tools, rate limits, or privacy isolation dominate. State what should change instead and what evidence would reopen prompt-cache work.
 
-For project-change questions, answer first with `Change needed: yes`, `Change needed: no`, or `Change needed: unknown until <specific evidence>` when a single answer is accurate. If change types differ, use:
-
-```text
-Measurement change:
-Prompt behavior change:
-Provider/routing change:
-Confidence:
-Do first:
-Do not do yet:
-```
+For project-change questions, answer first with `Change needed: yes`, `Change needed: no`, or `Change needed: unknown until <specific evidence>` when a single answer is accurate. If change types differ, split the answer into `Measurement change`, `Prompt behavior change`, `Provider/routing change`, `Confidence`, `Do first`, and `Do not do yet`.
 
 ## Evidence-Bearing Findings
 
@@ -127,128 +148,113 @@ Every actionable finding should expose uncertainty and a falsifiable validation 
 source | severity | provider/engine | issue | evidence | evidence_type | confidence | impact_condition | cache impact | safe_first_action | fix | validation | do_not_do_yet
 ```
 
-Use evidence types such as `confirmed from code`, `confirmed from telemetry`, `provider-doc hypothesis`, or `needs validation`. State impact conditions such as "matters if this path is hot, repeated, and has a long stable prefix" instead of implying guaranteed savings.
+Use evidence types such as `confirmed from code`, `confirmed from telemetry`, `provider-doc hypothesis`, or `needs validation`. State impact conditions such as "matters if this path is hot, repeated, and has a long stable prefix" rather than implying guaranteed savings.
 
-Group review output as:
-- **Confirmed findings**: supported by code/config/telemetry and applicable to the project path.
-- **Hypotheses**: plausible risks needing usage logs, rendered payloads, route metrics, or provider docs.
-- **Not applicable**: generic cache advice ruled out by project context.
+Group output as **Confirmed findings** (code/config/telemetry evidence applicable to this path), **Hypotheses** (need usage logs, rendered payloads, route metrics, or provider docs), and **Not applicable** (generic advice ruled out by project context).
 
 ## Explicit Review Default
 
-If this skill is explicitly invoked and the user asks only "review", "do a review", "сделай ревью", or equivalent, default to a cache-focused review of the available diff or repository. Treat the request as a prompt/prefix/KV cache audit and report cache-impact findings first. Do not perform a general code review unless the user explicitly asks for one.
+If this skill is explicitly invoked and the user asks only "review", "сделай ревью", or equivalent, default to a cache-focused review of the available diff or repository, treating it as a prompt/prefix/KV cache audit and reporting cache-impact findings first. Do not perform a general code review unless the user explicitly asks for one.
 
 ## Use-Case Map
 
-Classify the request before auditing. For the deeper artifact matrix, load `references/use-cases.md`.
+Classify the request before auditing. Deeper artifact matrix: `references/use-cases.md`.
 
 | Scenario | Common triggers | Inspect first |
 |---|---|---|
-| Cost or migration audit | bill increased, provider comparison, cache discount not visible | usage logs, billing export, static/dynamic/output token estimates, provider references |
-| Prompt/code audit | `cached_tokens=0`, prompt builder changed, schema drift | prompt renderers, SDK calls, tools, `response_format`, serialization |
-| Mechanics/latency audit | cache hit did not reduce cost/latency, decode dominates | `references/mechanics.md`, token/TTFT traces, output length, streaming timestamps |
-| Managed-router audit | OpenRouter cache writes without reads, fallback, sticky routing | OpenRouter request body, `provider` routing fields, model(s), plugins, usage metadata |
-| Agent/coding-assistant audit | agent got expensive, dynamic tools, MCP routing, compaction | agent loop, tool registry, history compaction, per-step cache logs |
-| Deployment audit | vLLM/SGLang cache misses, TTFT after scaling | Docker/Kubernetes/Helm/gateway config, engine flags, KV metrics |
-| Observability/CI audit | need dashboard, release guardrail, prefix smoke test | `references/observability.md`, traces, snapshots, prefix/tool/schema hashes |
-| Quick operational triage | low hit rate, high bill, TTL confusion, wrapper ambiguity | `references/operational-playbook.md`, usage fields, rendered request pair |
+| Cost or migration | bill increased, provider comparison, discount not visible | usage logs, billing export, token estimates, provider references |
+| Prompt/code | `cached_tokens=0`, builder changed, schema drift | prompt renderers, SDK calls, tools, `response_format`, serialization |
+| Mechanics/latency | hit did not cut cost/latency, decode dominates | `references/mechanics.md`, TTFT traces, output length, stream timestamps |
+| Deployment | vLLM/SGLang misses, TTFT after scaling | Docker/Kubernetes/Helm/gateway config, engine flags, KV metrics |
+| Observability/CI | dashboard, release guardrail, prefix smoke test | `references/observability.md`, traces, snapshots, prefix/tool/schema hashes |
+| Quick triage | low hit rate, high bill, TTL confusion, wrapper ambiguity | `references/operational-playbook.md`, usage fields, rendered request pair |
 
 ## Scenario References
 
-Load only what the detected scenario needs:
-
-- Quick triage: `references/operational-playbook.md`.
-- Cost or migration: `references/economics.md`, plus provider references.
-- Mechanics, latency, or self-hosted compute: `references/mechanics.md`.
-- Observability, dashboards, alerts, or CI guardrails: `references/observability.md`.
-- Release, incident, deploy, or monitoring: `references/predeploy-checklist.md`.
-- OpenRouter or managed provider routing: `references/openrouter.md`.
-- Agents, coding assistants, MCP, or dynamic tools: `references/agent-tools.md`.
-- Self-hosted SGLang: `references/sglang.md`.
-- Full report handoff: `references/report-template.md`.
-- Machine-readable anti-pattern rules: `references/rules.json`.
+Beyond the Use-Case Map column above, load `references/economics.md` for cost or
+migration, `references/predeploy-checklist.md` for release or incident work,
+`references/agent-tools.md` for agents, MCP, and dynamic tools, and
+`references/rules.json` for anti-pattern rules.
 
 ## Bundled Scripts
 
 Use scripts when deterministic evidence is better than prose:
 
-- `scripts/prefix_stability_check.py`: perform a raw whole-input comparison; use `--canonical-json` only when sorted-key normalization is intentional. It does not prove explicit breakpoint reuse.
-- `scripts/layout_linter.py`: inspect layout anti-patterns and validate direct GPT-5.6 `prompt_cache_options` and `prompt_cache_breakpoint` placement. Provider wrappers remain unvalidated.
-- `scripts/analyze_usage_logs.py`: summarize JSON/JSONL/CSV usage, including OpenAI `cache_write_tokens`. Use `--accounting-mode` only to resolve wrapper fields whose inclusive/additive meaning is known externally.
-- `scripts/estimate_cache_roi.py`: estimate read/write cost with caller-supplied prices. For paid writes, pass `--cache-write-rate` and `--cache-write-input-price-per-mtok`.
+- `scripts/prefix_stability_check.py`: raw whole-input comparison; use `--canonical-json` only when sorted-key normalization is intentional. It does not prove explicit breakpoint reuse.
+- `scripts/layout_linter.py`: inspect layout anti-patterns and validate direct GPT-5.6 `prompt_cache_options` and `prompt_cache_breakpoint` placement; provider wrappers remain unvalidated.
+- `scripts/analyze_usage_logs.py`: summarize JSON/JSONL/CSV usage, including `cache_write_tokens`, with evidence fields per record. Use `--accounting-mode` only to resolve wrapper fields whose inclusive/additive meaning is known externally.
+- `scripts/estimate_cache_roi.py`: estimate read/write cost with caller-supplied prices; for paid writes pass `--cache-write-rate` and `--cache-write-input-price-per-mtok`.
 - `scripts/extract_llm_calls.py`: scan a repository for provider calls, cache-control fields, routing signals, and self-hosted engine hints.
-- `scripts/render_audit_report.py`: combine usage summaries and findings into Markdown or JSON; pass estimator output through `--roi-json` before making a cost-direction claim.
+- `scripts/render_audit_report.py`: combine usage summaries and findings into Markdown or JSON with repeatable `--cache-plane` and one status flag per clinic dimension, such as `--evidence-quality` or `--usage-accounting`; pass estimator output through `--roi-json` before making a cost-direction claim.
 - `scripts/validate_skill_package.py`: validate frontmatter, referenced files, eval JSON, and Python helper syntax.
 - `scripts/run_trigger_eval.py`: summarize positive and negative trigger-eval coverage.
 
-These scripts are provider-tokenizer and billing approximations. Provider usage and billing exports remain authoritative.
+These scripts are tokenizer and billing approximations; provider usage and billing exports remain authoritative.
 
 ### Script Transparency Rule
 
-Before running any bundled script, explain what each bundled script reads, writes, and whether it uses network. Also state why the script is needed, whether it scans the whole repository or a targeted path, and the expected runtime class: seconds, tens of seconds, or minutes.
-
-Default to targeted scans for large repos or narrow questions. If a script may read secrets, environment files, generated artifacts, large logs, or production exports, say so explicitly and ask for approval unless the user already requested that exact scan. Bundled scripts do not send files to a network service.
+Before running any bundled script, explain what each bundled script reads, writes, and whether it uses network. State why it is needed, whether it scans the whole repository or a targeted path, and the expected runtime class: seconds, tens of seconds, or minutes. Default to targeted scans for large repos or narrow questions. If a script may read secrets, environment files, generated artifacts, large logs, or production exports, say so and ask for approval unless the user already requested that exact scan. Bundled scripts do not send files to a network service.
 
 ## Freshness Gate
 
-Provider facts are volatile. Before exact provider claims, open the relevant provider reference and verify official sources when browsing is available.
+Provider facts are volatile. Before exact claims about pricing, cache discounts, storage or write premiums, current models, regional availability, thresholds, granularity, TTL, retention, usage fields, API parameters, tool-search, allowed-tools, defer-loading, or cache-control semantics, open the relevant provider reference and verify official sources when browsing is available.
 
-Verify before exact claims about pricing, cache discounts, storage or write premiums, current models, regional availability, cache thresholds, granularity, TTL, retention, usage fields, API parameters, tool-search, allowed-tools, defer-loading, or cache-control semantics.
-
-If official docs cannot be checked, say provider facts are unverified and avoid exact numbers. Use bundled references as heuristics, not current truth.
+If official docs cannot be checked, say provider facts are unverified and avoid exact numbers; bundled references are heuristics, not current truth.
 
 ## Provider Detection
 
 Search SDK imports, API base URLs, model names, deployment manifests, and engine flags. Load wrapper/router references before generic provider advice when signals overlap.
 
 - OpenRouter: `openrouter`, `openrouter.ai/api/v1`, `openrouter/auto` -> `references/openrouter.md`.
-- Azure, Bedrock, Qwen/DashScope, Vercel AI SDK, and Mastra wrappers: load `references/azure-openai.md`, `references/bedrock.md`, `references/qwen.md`, `references/vercel-ai-sdk.md`, or `references/mastra.md` before direct-provider references.
-- Direct providers: OpenAI -> `references/openai.md`; Anthropic -> `references/anthropic.md`; DeepSeek -> `references/deepseek.md`; Gemini -> `references/gemini.md`; YandexGPT -> `references/yandexgpt.md`; z.ai -> `references/zai.md`.
-- Self-hosted engines: `vllm`, `vllm bench serve`, `prefix_repetition`, `benchmark_prefix_caching.py`, KV-cache events, or KV transfer connectors -> `references/vllm.md`; SGLang/RadixAttention/HiCache/PD disaggregation -> `references/sglang.md`.
+- Wrappers first: `references/azure-openai.md`, `references/bedrock.md`, `references/qwen.md`, `references/vercel-ai-sdk.md`, `references/mastra.md`.
+- Direct: OpenAI -> `references/openai.md`; Anthropic -> `references/anthropic.md`; DeepSeek -> `references/deepseek.md`; Gemini -> `references/gemini.md`; YandexGPT -> `references/yandexgpt.md`; z.ai -> `references/zai.md`.
+- Self-hosted: `vllm`, `vllm bench serve`, `prefix_repetition`, `benchmark_prefix_caching.py`, KV-cache events, or KV transfer connectors -> `references/vllm.md`; SGLang/RadixAttention/HiCache/PD disaggregation -> `references/sglang.md`.
 
 If detection is ambiguous, ask which provider/engine is in use.
 
 ## Audit Flow
 
-1. Detect mode, provider, and use-case scenario.
-2. Load only the relevant scenario and provider references.
-3. Apply the Freshness Gate for provider facts.
-4. Run the Project Context Gate and Applicability Gate.
-5. Map prompt structure in order: tools, schemas, system/developer instructions, examples, static documents/context, retrieved context, conversation history, user-specific data, volatile values.
-6. Mark segments as static, semi-static, dynamic, or volatile.
-7. Measure cache ratio, TTFT/prefill latency, output/decode time, cache writes vs reads, and correlation with deploys, SDK changes, prompt changes, replica count, or agent steps.
-8. Apply anti-patterns from `references/rules.json`.
-9. For agents, log per-step `cached_tokens` or `cache_read_input_tokens`, `prefix_hash`, `tools_count`, sorted tool-name hash, output tokens, streaming timestamps, compaction events, and actual managed-router provider/model.
-10. Apply provider-specific checks from the loaded reference.
-11. Report findings with evidence type, confidence, impact condition, safe first action, fix, validation, and `do_not_do_yet`.
-12. When making code changes, verify prefix stability before claiming success.
+1. Detect mode, provider/engine, cache planes, and scenario; load only the matching scenario and provider references and apply the Freshness Gate.
+2. Run the Project Context Gate and Applicability Gate.
+3. With a repository, start from code and config: provider calls, cache controls, routing hints, prompt builders and rendering, tool/schema registries, history and compaction, SDK parameters, and self-hosted engine signals. `scripts/extract_llm_calls.py` makes that scan deterministic.
+4. Inspect env defaults, feature flags, gateway/router settings, Compose, Kubernetes, Helm, vLLM/SGLang flags, and replica topology.
+5. Map prompt structure in order: tools, schemas, system/developer instructions, examples, static documents, retrieved context, history, user data, volatile values; mark each segment static, semi-static, dynamic, or volatile.
+6. Ask for usage logs, rendered payload pairs, traces, or billing exports only when telemetry is needed to confirm a finding, compare prefixes, calculate ROI, or correlate incidents.
+7. Apply the Usage Evidence Contract, then measure cache ratio, TTFT/prefill, decode time, writes vs reads, and correlation with deploys, SDK/prompt changes, replica count, or agent steps.
+8. Apply `references/rules.json` anti-patterns and provider-specific checks from the loaded reference.
+9. For agents, log per-step `cached_tokens` or `cache_read_input_tokens`, `prefix_hash`, `tools_count`, sorted tool-name hash, output tokens, streaming timestamps, compaction events, and the actual routed provider/model.
+10. Report findings with evidence type, confidence, impact condition, safe first action, fix, validation, and `do_not_do_yet`, plus the Cache Clinic Summary.
+11. When changing code, verify prefix stability before claiming success.
+
+Bundled fixtures are examples and regression data; scripts accept normal JSON,
+JSONL, CSV usage logs and request payloads.
 
 ## Audit Playbooks
 
 Use these starts after provider detection and Freshness Gate:
 
-- **OpenAI cached_tokens=0**: check prompt length/threshold, first-prefix drift, Responses vs Chat usage fields, `prompt_cache_key`, model-specific cache controls, output-token dominance, and wrapper ambiguity.
-- **GPT-5.6 paid writes**: validate `prompt_cache_options` and marked content blocks, separate inclusive `cached_tokens`/`cache_write_tokens` from input totals, and require current pricing before claiming savings. Prefer explicit mode when implicit latest-message writes churn on a volatile suffix.
-- **Claude/Bedrock/OpenRouter writes without reads**: distinguish write/create fields from read/hit fields, then inspect breakpoint placement, dynamic content before breakpoint, TTL/retention, model/region/API support, fallback routing, and actual routed provider/model.
-- **Gemini Interactions or managed session cache**: distinguish an explicit cache object from an opaque continuation handle (`previous_interaction_id` or `previous_response_id`), preserve it only inside the intended conversation, and normalize `total_cached_tokens` as inclusive before comparing routes.
-- **KV events, HiCache, or PD disaggregation**: separate prompt-prefix mismatch from eviction, tier transfer/offload, event delivery, and decode-side KV reuse. Compare TTFT/prefill and worker/tier metrics before changing prompt construction.
-- **Dynamic tools in long agent loops**: compare `tools_count`, sorted tool-name hash, `prefix_hash`, mode state, and cache fields per step. Prefer stable route-level tool bundles, sorted schemas, provider-supported allowed tools/tool search/deferred loading, or self-hosted masking after checking current docs.
-- **High hit rate but no savings**: separate input savings from total cost and final latency. Check output-token share, decode time, external tool time, TPM/rate limits, and cache read/write pricing assumptions.
+- **OpenAI cached_tokens=0**: check prompt length/threshold, first-prefix drift, Responses vs Chat usage fields, `prompt_cache_key`, model cache controls, output-token dominance, and wrapper ambiguity.
+- **GPT-5.6 paid writes**: validate `prompt_cache_options` and marked blocks, separate inclusive `cached_tokens`/`cache_write_tokens` from input totals, and require current pricing before claiming savings. Prefer explicit mode when implicit writes churn on a volatile suffix.
+- **Claude/Bedrock/OpenRouter writes without reads**: distinguish write/create from read/hit fields, then inspect breakpoint placement, dynamic content before it, TTL/retention, model/region/API support, fallback routing, and the routed provider/model.
+- **Gemini Interactions or managed session cache**: distinguish an explicit cache object from an opaque continuation handle (`previous_interaction_id`, `previous_response_id`), keep it inside the intended conversation, and normalize `total_cached_tokens` as inclusive before comparing routes.
+- **KV events, HiCache, or PD disaggregation**: separate prefix mismatch from eviction, tier transfer/offload, event delivery, and decode-side KV reuse. Compare TTFT/prefill and worker/tier metrics first.
+- **Dynamic tools in long agent loops**: compare `tools_count`, sorted tool-name hash, `prefix_hash`, mode state, and cache fields per step. Prefer stable route-level tool bundles, sorted schemas, provider allowed tools/tool search/deferred loading, or self-hosted masking.
+- **High hit rate but no savings**: separate input savings from total cost and final latency. Check output-token share, decode time, external tool time, TPM/rate limits, and read/write pricing assumptions.
 - **OpenAI-compatible wrapper ambiguity**: if `base_url`, Azure, OpenRouter, Bedrock, DashScope/Qwen, or another gateway wraps an OpenAI SDK, load the wrapper reference first.
-- **Self-hosted multi-replica miss**: inspect gateway/service routing, prefix-aware hashing, tokenizer/chat-template drift, `max_model_len`, KV block pressure, eviction metrics, and route/replica-level hit metrics.
-- **New provider docs project-change audit**: compare new provider facts against current code, references, evals, and tests. Recommend no code change when the project already encodes the behavior or the fact is not applicable.
+- **Self-hosted multi-replica miss**: inspect gateway/service routing, prefix-aware hashing, tokenizer/chat-template drift, `max_model_len`, KV block pressure, eviction, and route/replica hit metrics.
+- **New provider docs**: compare new provider facts against current code, references, evals, and tests; recommend no change when the project already encodes the behavior.
 
 ## Rule Categories
 
-Use `references/rules.json` for the machine-readable AP-1 through AP-12 anti-pattern inventory. Use this priority taxonomy when turning rules into findings:
+`references/rules.json` holds the machine-readable AP-1 to AP-12 inventory. Turn rules into findings with this priority taxonomy:
 
 | Priority | Category | Examples |
 |---|---|---|
-| P0 | Provider correctness | usage fields, provider thresholds, cache activation, TTL/retention |
+| P0 | Provider correctness | usage fields, thresholds, cache activation, TTL/retention |
 | P1 | Prefix stability | static-first ordering, no volatile early values, stable tools/schemas |
-| P2 | Measurement | cache ratio, writes vs reads, output-token share, TTFT vs final latency |
-| P3 | Architecture | RAG/CAG, response cache distinction, multi-tenant boundaries, routing locality |
-| P4 | Reporting | file-line findings, before/after layout, ROI assumptions, validation commands |
+| P2 | Measurement | denominator status, cache ratio, writes vs reads, output share, TTFT |
+| P3 | Architecture | RAG/CAG, plane separation, multi-tenant boundaries, routing locality |
+| P4 | Reporting | file-line findings, before/after layout, ROI assumptions, validation |
 
 ## Severity
 
@@ -256,54 +262,45 @@ Use `references/rules.json` for the machine-readable AP-1 through AP-12 anti-pat
 
 Assign severity only after the Project Context Gate and Applicability Gate. A real anti-pattern in a cold, sparse, single-run, output-bound, or non-cacheable route is not automatically high severity.
 
-- **Critical**: confirmed metric drop or cache miss on a large shared prefix, expensive model, high traffic, long agent trajectory, or multi-replica production path.
-- **High**: likely cache killer found in a hot path, or telemetry/traffic/token evidence shows meaningful cache/cost/TTFT impact but metrics are incomplete.
+- **Critical**: confirmed metric drop or miss on a large shared prefix, expensive model, high traffic, long agent trajectory, or multi-replica production path.
+- **High**: likely cache killer in a hot path, or evidence shows meaningful cache/cost/TTFT impact but metrics are incomplete.
 - **Medium**: pattern can fragment cache but impact depends on traffic shape.
 - **Low**: defensive cleanup, documentation, or monitoring improvement.
 
-If hotness, prefix length, repeat cadence, or cost impact is unknown, prefer `medium` or `needs validation` and state what would escalate or lower severity.
+If hotness, prefix length, cadence, or cost impact is unknown, prefer `medium` or `needs validation` and state what would escalate or lower severity.
 
 ## Report Format
 
-Default to terse findings first. Use the evidence-bearing format when possible:
-
-```text
-file:line | severity | provider/engine | issue | cache impact | fix | validation
-```
-
+Default to terse findings first, preferring the evidence-bearing format:
+`file:line | severity | provider/engine | issue | cache impact | fix | validation`.
 For full handoff reports, load `references/report-template.md`.
 
 ## Agent-First Quality Bar
 
 Before finalizing:
-- Answer the decision the user asked for: change needed, no change, or evidence missing.
-- Prefer wrapper/router references over generic provider references when both signals exist.
-- Do not make exact provider claims without the relevant reference and Freshness Gate.
-- Distinguish cache miss, write-without-read, uneconomic hit, decode-bound latency, rate-limit pressure, and privacy-driven isolation.
-- Include validation that can falsify the recommendation: prefix fingerprints, provider usage fields, route/replica metrics, or cost/latency split.
+- Answer the decision asked for: change needed, no change, or evidence missing.
+- Prefer wrapper/router references over generic provider references when both signals exist, and make no exact provider claim without the reference and Freshness Gate.
+- Distinguish plane, cache miss, write-without-read, uneconomic hit, decode-bound latency, rate-limit pressure, and privacy-driven isolation.
+- Include falsifiable validation: prefix fingerprints, usage fields, route/replica metrics, or cost/latency split.
 - Do not propose cache controls, cache keys, or routing hints when the Not worth caching contract applies.
 
 ## Verification
 
-Do not claim a fix works until one of these is true:
-- Prefix-stability fixes: rendered cacheable prefix fingerprint is unchanged across different users/timestamps/queries.
-- Provider fixes: repeated calls show cache-read/cached-token fields increasing according to the provider reference.
-- Routing fixes: repeated prefix families land on the intended route and cache metrics improve by route.
-- vLLM/self-hosted fixes: prefix cache hit metrics and KV block pressure metrics improve under a representative workload.
+Do not claim a fix works until one holds:
+- Prefix fixes: the rendered cacheable prefix fingerprint is unchanged across users, timestamps, and queries.
+- Provider fixes: repeated calls show cache-read/cached-token fields increasing per the provider reference.
+- Routing fixes: repeated prefix families land on the intended route and metrics improve by route.
+- Self-hosted fixes: prefix cache hit and KV block pressure metrics improve under a representative workload.
 
 Recommend a CI/smoke check that renders representative prompts and fails when the cacheable prefix changes unexpectedly.
 
 ## Advisory Questions
 
-If no codebase is available, ask only the missing questions needed to diagnose:
-
-1. Which provider or inference engine?
-2. Is this a cost/migration, prompt/code, agent, deployment, or observability/CI audit?
-3. What artifacts are available: request code, rendered prompts, usage logs, deployment config, dashboards, evals?
-4. What are median/p95 input tokens, static prefix tokens, output tokens, and agent steps?
-5. What cache usage fields are visible in responses?
-6. Are there multiple replicas or gateways?
-7. Are tools/schemas stable across requests and agent steps?
-8. Is history append-only, compacted, or summarized?
-9. Are cache keys, salts, or routing hints per-user/per-request or shared by prefix family?
-10. What changed before the cache hit rate or TTFT regressed?
+With no codebase, ask only what is still missing: provider or engine; cache
+planes in scope; audit type (cost/migration, prompt/code, agent, deployment,
+observability/CI); available artifacts (request code, rendered prompts, usage
+logs, deployment config, dashboards, evals); median/p95 input, static-prefix,
+and output tokens plus agent steps; visible cache usage fields; replica and
+gateway count; tool/schema stability across steps; history handling; whether
+cache keys, salts, or routing hints are per-user or shared by prefix family;
+and what changed before the hit rate or TTFT regressed.

--- a/audit-prompt-caching/SKILL.md
+++ b/audit-prompt-caching/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: audit-prompt-caching
 description: >
-  Use whenever the user mentions LLM prompt/prefix cache misses, cached_tokens=0,
-  cache_read_input_tokens, cache_write_tokens, prompt_cache_key,
-  prompt_cache_options, cache_control/cachePoint, TTFT/prefill, KV reuse,
-  LLM cost or speed regressed on repeated long prompts, or speeding up agents
-  through cache stability. Use for LLM request shape changes:
-  prompt text/order/builders, tools, schemas, response_format, model/router,
+  Use whenever the user mentions cached_tokens=0, total_cached_tokens,
+  cache_read_input_tokens, cache_creation_input_tokens, cache_write_tokens,
+  prompt_cache_key, prompt_cache_options, prompt_cache_breakpoint,
+  previous_interaction_id, cache_control/cachePoint, TTFT, KV reuse,
+  LLM cost or speed regressed on repeated long prompts, or speeding up agents.
+  LLM request shape changes: tools, schemas, response_format, model/router,
   agent loops, compaction. Not for generic prompt writing/RAG, token counts,
   or non-LLM perf.
 ---
@@ -30,7 +30,7 @@ TTFT, prefill latency, or self-hosted KV reuse. Typical triggers:
 - Cache hit rate, TTFT, prefill latency, or input-token cost changed, or a reported hit rate is not trusted.
 - LLM cost or speed regressed around repeated long prompts, shared static context, long-context agents, or tool-heavy loops.
 - LLM request shape changed where repeated long prompts, TTFT, cached-token telemetry, or LLM cost matter.
-- Prompt text, message order, request builders, tools, schemas, `response_format`, provider API surface, model/router settings, agent loop structure, or context compaction changed.
+- Any prompt text, message order, request builders, tools, schemas, `response_format`, provider API surface, model/router settings, agent loop structure, or context compaction changed.
 - The route uses long system prompts, tool catalogs, schemas, static documents, few-shot examples, repeated RAG/CAG context, or provider cache APIs.
 - vLLM/SGLang/self-hosted deployments have multi-replica routing, KV pressure, tokenizer/chat-template drift, cache salts, or APC benchmarks such as `vllm bench serve`, `prefix_repetition`, or `benchmark_prefix_caching.py`.
 

--- a/audit-prompt-caching/evals/evals.json
+++ b/audit-prompt-caching/evals/evals.json
@@ -85,6 +85,21 @@
       "id": 17,
       "prompt": "OpenAI GPT-5.6 telemetry has high cache_write_tokens and few reads. Is the cache saving money?",
       "expected_output": "Treat cache fields as inclusive input breakdowns and require current read, write, input, and output pricing before a cost conclusion."
+    },
+    {
+      "id": 18,
+      "prompt": "Our LiteLLM gateway reports a 70 percent gateway response-cache hit rate, but the OpenAI cached_tokens stays 0 on the same route. Is prompt caching working?",
+      "expected_output": "Separate the gateway_response plane from the provider_prompt plane; a gateway response-cache hit is not provider prefix reuse and each plane needs its own evidence."
+    },
+    {
+      "id": 19,
+      "prompt": "An unknown OpenAI-compatible wrapper reports a 95 percent cache hit rate in our dashboard. Can we book the savings this quarter?",
+      "expected_output": "Unknown wrapper accounting stays ambiguous, so denominator_status is ambiguous and the ratio is non-decision-grade: no savings claim until the accounting semantics are proven."
+    },
+    {
+      "id": 20,
+      "prompt": "We only have a prompt builder diff: no usage logs, no routing data, no cost model, and no isolation review. Give me the cache clinic summary.",
+      "expected_output": "Report every unproven clinic dimension as unknown instead of dropping it, and give no aggregate score, grade, or rank across dimensions."
     }
   ]
 }

--- a/audit-prompt-caching/references/observability.md
+++ b/audit-prompt-caching/references/observability.md
@@ -14,6 +14,43 @@ Use for dashboards, alerts, traces, release guardrails, and CI smoke tests.
 
 Do not log raw prompts. Use keyed hashes for tenant/user-derived or low-entropy prompt content.
 
+## Usage Evidence Contract
+
+`analyze_usage_logs.py --jsonl-normalized` emits one canonical event per record. Four fields decide whether a cache ratio is decision-grade:
+
+```json
+{
+  "schema_version": 1,
+  "source_fields": {
+    "input_tokens": "usage.prompt_tokens",
+    "cached_tokens": "usage.prompt_tokens_details.cached_tokens",
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "cache_write_tokens": null,
+    "output_tokens": "usage.completion_tokens"
+  },
+  "accounting_semantics": "inclusive",
+  "denominator_status": "valid",
+  "warnings": []
+}
+```
+
+- `schema_version` versions this normalized event contract, not the provider's raw schema.
+- `source_fields` names which raw field produced each canonical value, or `null` when the value is absent or derived.
+- `accounting_semantics` is `inclusive`, `additive`, or `ambiguous`.
+- `denominator_status` is `valid`, `ambiguous` (unresolved wrapper semantics, or no measured input), or `invalid` (an adapter invariant is contradicted, for example cached input above an inclusive input total). The aggregate takes the worst observed status: `invalid > ambiguous > valid`.
+- `warnings` carries the stable normalization warning codes; it is the only warning list.
+
+Only a `valid` denominator supports a savings or hit-rate claim. Report `ambiguous` and `invalid` ratios as non-decision-grade evidence and fix accounting first.
+
+### Source Path Handling
+
+`source_fields` values are human-readable dot paths for reviewers, not machine-resolvable JSONPath expressions. Unknown wrapper envelopes can place usage under dynamic map keys, so a path may not be reusable as a selector and can itself carry request- or tenant-derived identifiers. Treat normalized telemetry as sensitive and apply the same handling policy as the rest of your token telemetry. Paths never contain leaf values or raw envelopes.
+
+### Backward Compatibility
+
+Event, summary, and report changes are additive: no existing key is renamed or removed, and strict JSON consumers must allow new event, summary, and report fields rather than failing closed. Only normalized events are versioned today; aggregate and report schema versioning remains deferred until a breaking migration needs it.
+
 ## Dashboard
 
 Show cache read ratio, write/read ratio, cached-token share, output-token share, TTFT/prefill by route, final latency, route/provider/replica split, prompt/schema/tool hash changes, deploy correlation, and top prefix families by cost.

--- a/audit-prompt-caching/references/report-template.md
+++ b/audit-prompt-caching/references/report-template.md
@@ -30,6 +30,36 @@ Do not do yet:
 source | severity | provider/engine | issue | evidence | evidence_type | confidence | impact_condition | cache impact | safe_first_action | fix | validation | do_not_do_yet
 ```
 
+## Cache Planes
+
+Name every plane the audit actually covers. `render_audit_report.py --cache-plane` is repeatable and renders in this fixed order regardless of input order:
+
+1. `gateway_response` — response reuse at a gateway or proxy.
+2. `provider_prompt` — provider-managed prompt/prefix caching in provider usage telemetry.
+3. `engine_kv` — attention KV reuse inside a self-hosted engine.
+4. `external_kv` — KV blocks persisted or transferred outside the serving process.
+5. `semantic_response` — similarity-based reuse of a prior response.
+
+With no `--cache-plane`, the JSON list is empty and Markdown renders `Cache planes: unknown`. The renderer never infers a plane from a provider, model, or route name.
+
+## Cache Clinic Summary
+
+Report seven dimensions, each with exactly one status of `pass/warning/fail/unknown/not_applicable`:
+
+| Dimension | CLI flag | Question |
+|---|---|---|
+| `applicability` | `--applicability` | Is caching the right lever for this route? |
+| `evidence_quality` | `--evidence-quality` | Do conclusions rest on rendered payloads, telemetry, or hypotheses? |
+| `prefix_stability` | `--prefix-stability` | Is the cacheable prefix byte/token stable? |
+| `usage_accounting` | `--usage-accounting` | Is the cache-hit denominator trustworthy? |
+| `routing_locality` | `--routing-locality` | Do repeated prefixes land on the same cache? |
+| `economics` | `--economics` | Does the read/write price shape justify the change? |
+| `isolation` | `--isolation` | Is cache-key and tenant scope safe? |
+
+Every dimension defaults to `unknown`. Leave missing evidence visible as `unknown` instead of excluding it, and emit no aggregate score, grade, rank, or traffic-light roll-up across dimensions.
+
+An `ambiguous` or `invalid` usage denominator can never be reported as `usage_accounting: pass`; the renderer rejects that combination, forces `warning`/`fail`, and marks the hit ratio non-decision-grade.
+
 ## Evidence Needed Next
 
 List rendered prompt pair, usage fields, route/model/provider, prefix/tool/schema hashes, TTFT/prefill, output tokens, and deployment/router/KV metrics needed to raise or lower severity.

--- a/audit-prompt-caching/scripts/analyze_usage_logs.py
+++ b/audit-prompt-caching/scripts/analyze_usage_logs.py
@@ -467,13 +467,43 @@ def infer_provider(record):
     return usage_adapter_for(record).provider
 
 
+def cache_benefit_tokens(row):
+    return row["cached_tokens"] + row["cache_read_input_tokens"]
+
+
+def cache_write_total_tokens(row):
+    return row["cache_write_tokens"] + row["cache_creation_input_tokens"]
+
+
+def inclusive_aggregates(row):
+    """Return the derived inclusive totals that must fit inside the input total."""
+    benefit = cache_benefit_tokens(row)
+    write_total = cache_write_total_tokens(row)
+    return (
+        ("cache_benefit_tokens", benefit),
+        ("cache_write_total_tokens", write_total),
+        ("cache_accounted_input_tokens", benefit + write_total),
+    )
+
+
 def inclusive_violations(row):
-    """Return inclusive cache components that cannot fit inside the input total."""
-    return [
+    """Return inclusive cache fields that cannot fit inside the input total.
+
+    A single raw component that alone exceeds the input total is the clearer
+    evidence, so aggregates are only reported when every component fits and the
+    sum still contradicts the reported input.
+    """
+    individual = [
         field
         for field in INCLUSIVE_CACHE_COMPONENTS
         if row[field] > row["input_tokens"]
     ]
+    if individual:
+        return individual
+    for field, value in inclusive_aggregates(row):
+        if value > row["input_tokens"]:
+            return [field]
+    return []
 
 
 def denominator_status(row, semantics, total_input_tokens):
@@ -506,20 +536,27 @@ def normalization_warnings(adapter, row, semantics, index):
                 ),
             }
         )
-    if adapter.shape == "openai":
-        for field in ("cached_tokens", "cache_write_tokens"):
-            if row[field] > row["input_tokens"]:
-                warnings.append(
-                    {
-                        "code": "OPENAI_CACHE_BREAKDOWN_EXCEEDS_INPUT",
-                        "index": index,
-                        "field": field,
-                        "message": (
-                            f"OpenAI {field} exceeds the endpoint input token total"
-                        ),
-                    }
-                )
-    elif semantics == "inclusive":
+    openai_violations = (
+        [
+            field
+            for field in ("cached_tokens", "cache_write_tokens")
+            if row[field] > row["input_tokens"]
+        ]
+        if adapter.shape == "openai"
+        else []
+    )
+    for field in openai_violations:
+        warnings.append(
+            {
+                "code": "OPENAI_CACHE_BREAKDOWN_EXCEEDS_INPUT",
+                "index": index,
+                "field": field,
+                "message": (
+                    f"OpenAI {field} exceeds the endpoint input token total"
+                ),
+            }
+        )
+    if semantics == "inclusive" and not openai_violations:
         for field in inclusive_violations(row):
             warnings.append(
                 {
@@ -543,18 +580,16 @@ def normalize_record(record, accounting_mode=None, index=None):
         else adapter.semantics
     )
 
-    cache_benefit_tokens = row["cached_tokens"] + row["cache_read_input_tokens"]
-    cache_write_total_tokens = (
-        row["cache_write_tokens"] + row["cache_creation_input_tokens"]
-    )
+    benefit_tokens = cache_benefit_tokens(row)
+    write_total_tokens = cache_write_total_tokens(row)
     total_input_tokens = row["input_tokens"]
     if semantics == "additive":
-        total_input_tokens += cache_benefit_tokens + cache_write_total_tokens
+        total_input_tokens += benefit_tokens + write_total_tokens
 
     row.update(
         {
-            "cache_benefit_tokens": cache_benefit_tokens,
-            "cache_write_total_tokens": cache_write_total_tokens,
+            "cache_benefit_tokens": benefit_tokens,
+            "cache_write_total_tokens": write_total_tokens,
             "total_input_tokens": total_input_tokens,
             "accounting_semantics": semantics,
             "source_fields": source_fields,

--- a/audit-prompt-caching/scripts/analyze_usage_logs.py
+++ b/audit-prompt-caching/scripts/analyze_usage_logs.py
@@ -106,13 +106,17 @@ def extracted_value(value, names, prefix):
 
 
 def first_number(record, names):
+    """Return the first nonzero alias, keeping the first present alias as evidence."""
+    present_path = None
     for obj, prefix in walk(record):
         for name in names:
             if name in obj:
                 found = number(obj[name])
                 if found:
                     return found, dot_path(prefix, name)
-    return 0, None
+                if present_path is None:
+                    present_path = dot_path(prefix, name)
+    return 0, present_path
 
 
 def blank_source_fields():
@@ -121,6 +125,9 @@ def blank_source_fields():
 
 def extraction(**extracted):
     """Split per-field (value, path) pairs into canonical values and provenance."""
+    unknown = [field for field in extracted if field not in FIELD_ALIASES]
+    if unknown:
+        raise ValueError(f"non-canonical usage fields: {', '.join(sorted(unknown))}")
     row = {field: 0 for field in CANONICAL_USAGE_FIELDS}
     source_fields = blank_source_fields()
     for field, (value, path) in extracted.items():
@@ -469,11 +476,13 @@ def inclusive_violations(row):
     ]
 
 
-def denominator_status(row, semantics):
-    if semantics == "ambiguous":
-        return "ambiguous"
+def denominator_status(row, semantics, total_input_tokens):
     if semantics == "inclusive" and inclusive_violations(row):
         return "invalid"
+    if semantics == "ambiguous":
+        return "ambiguous"
+    if total_input_tokens <= 0:
+        return "ambiguous"
     return "valid"
 
 
@@ -549,7 +558,9 @@ def normalize_record(record, accounting_mode=None, index=None):
             "total_input_tokens": total_input_tokens,
             "accounting_semantics": semantics,
             "source_fields": source_fields,
-            "denominator_status": denominator_status(row, semantics),
+            "denominator_status": denominator_status(
+                row, semantics, total_input_tokens
+            ),
             "warnings": normalization_warnings(adapter, row, semantics, index),
         }
     )

--- a/audit-prompt-caching/scripts/analyze_usage_logs.py
+++ b/audit-prompt-caching/scripts/analyze_usage_logs.py
@@ -46,6 +46,19 @@ FIELD_ALIASES = {
     ),
 }
 
+CANONICAL_USAGE_FIELDS = tuple(FIELD_ALIASES)
+
+SCHEMA_VERSION = 1
+
+INCLUSIVE_CACHE_COMPONENTS = (
+    "cached_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+    "cache_write_tokens",
+)
+
+DENOMINATOR_PRECEDENCE = ("invalid", "ambiguous", "valid")
+
 BEDROCK_USAGE_FIELDS = (
     "InputTokens",
     "CacheReadInputTokens",
@@ -68,31 +81,63 @@ def number(value):
     return int(parsed)
 
 
-def walk(value):
+def walk(value, prefix=()):
+    """Yield every nested mapping together with its dot-path segments."""
     if isinstance(value, dict):
-        yield value
-        for child in value.values():
-            yield from walk(child)
+        yield value, prefix
+        for key, child in value.items():
+            yield from walk(child, (*prefix, str(key)))
     elif isinstance(value, list):
-        for child in value:
-            yield from walk(child)
+        for index, child in enumerate(value):
+            yield from walk(child, (*prefix, str(index)))
+
+
+def dot_path(prefix, name):
+    return ".".join((*prefix, name))
+
+
+def extracted_value(value, names, prefix):
+    """Return the first present canonical value and its exact raw dot path."""
+    if isinstance(value, dict):
+        for name in names:
+            if name in value:
+                return number(value[name]), dot_path(prefix, name)
+    return 0, None
 
 
 def first_number(record, names):
-    for obj in walk(record):
+    for obj, prefix in walk(record):
         for name in names:
             if name in obj:
                 found = number(obj[name])
                 if found:
-                    return found
-    return 0
+                    return found, dot_path(prefix, name)
+    return 0, None
+
+
+def blank_source_fields():
+    return {field: None for field in CANONICAL_USAGE_FIELDS}
+
+
+def extraction(**extracted):
+    """Split per-field (value, path) pairs into canonical values and provenance."""
+    row = {field: 0 for field in CANONICAL_USAGE_FIELDS}
+    source_fields = blank_source_fields()
+    for field, (value, path) in extracted.items():
+        row[field] = value
+        source_fields[field] = path
+    return row, source_fields
+
+
+def usage_envelope(record):
+    if not isinstance(record, dict):
+        return {}, ()
+    usage = record.get("usage")
+    return (usage, ("usage",)) if isinstance(usage, dict) else (record, ())
 
 
 def usage_object(record):
-    if not isinstance(record, dict):
-        return {}
-    usage = record.get("usage")
-    return usage if isinstance(usage, dict) else record
+    return usage_envelope(record)[0]
 
 
 GEMINI_INTERACTIONS_REQUEST_TOTAL_FIELDS = (
@@ -127,15 +172,6 @@ def has_any_field(value, names):
     return isinstance(value, dict) and any(name in value for name in names)
 
 
-def value_for(value, names):
-    if not isinstance(value, dict):
-        return None
-    for name in names:
-        if name in value:
-            return value[name]
-    return None
-
-
 def mapping_at(record, path):
     value = record
     for key in path:
@@ -146,23 +182,26 @@ def mapping_at(record, path):
 
 
 def first_usage_envelope(record, paths, fields):
+    """Return the first envelope carrying any of ``fields`` and its raw path."""
     for path in paths:
         value = mapping_at(record, path)
         if has_any_field(value, fields):
-            return value
-    return {}
+            return value, path
+    return {}, ()
 
 
 def has_bedrock_usage_fields(value):
     return has_any_field(value, BEDROCK_USAGE_FIELDS)
 
 
-def bedrock_usage_object(record):
+def bedrock_usage_envelope(record):
     metrics = mapping_at(record, ("metrics",))
-    return metrics if has_bedrock_usage_fields(metrics) else usage_object(record)
+    if has_bedrock_usage_fields(metrics):
+        return metrics, ("metrics",)
+    return usage_envelope(record)
 
 
-def gemini_interactions_usage_object(record):
+def gemini_interactions_usage_envelope(record):
     return first_usage_envelope(
         record,
         (
@@ -175,7 +214,7 @@ def gemini_interactions_usage_object(record):
     )
 
 
-def gemini_generate_content_usage_object(record):
+def gemini_generate_content_usage_envelope(record):
     return first_usage_envelope(
         record,
         (("usage_metadata",), ("usageMetadata",), ("usage",), ()),
@@ -183,110 +222,105 @@ def gemini_generate_content_usage_object(record):
     )
 
 
+def openai_breakdown_value(usage, usage_prefix, details, details_prefix, names):
+    value, path = extracted_value(details, names, details_prefix)
+    if path:
+        return value, path
+    return extracted_value(usage, names, usage_prefix)
+
+
 def extract_openai(record):
-    usage = usage_object(record)
+    usage, prefix = usage_envelope(record)
     if "prompt_tokens" in usage or "prompt_tokens_details" in usage:
-        input_tokens = number(usage.get("prompt_tokens"))
-        output_tokens = number(usage.get("completion_tokens"))
-        details = usage.get("prompt_tokens_details")
+        input_names, output_names = ("prompt_tokens",), ("completion_tokens",)
+        details_key = "prompt_tokens_details"
     else:
-        input_tokens = number(usage.get("input_tokens"))
-        output_tokens = number(usage.get("output_tokens"))
-        details = usage.get("input_tokens_details")
+        input_names, output_names = ("input_tokens",), ("output_tokens",)
+        details_key = "input_tokens_details"
+    details = usage.get(details_key)
     details = details if isinstance(details, dict) else {}
-    cached_tokens = details.get("cached_tokens", usage.get("cached_tokens"))
-    cache_write_tokens = details.get(
-        "cache_write_tokens", usage.get("cache_write_tokens")
+    details_prefix = (*prefix, details_key)
+    return extraction(
+        input_tokens=extracted_value(usage, input_names, prefix),
+        cached_tokens=openai_breakdown_value(
+            usage, prefix, details, details_prefix, ("cached_tokens",)
+        ),
+        cache_write_tokens=openai_breakdown_value(
+            usage, prefix, details, details_prefix, ("cache_write_tokens",)
+        ),
+        output_tokens=extracted_value(usage, output_names, prefix),
     )
-    return {
-        "input_tokens": input_tokens,
-        "cached_tokens": number(cached_tokens),
-        "cache_read_input_tokens": 0,
-        "cache_creation_input_tokens": 0,
-        "cache_write_tokens": number(cache_write_tokens),
-        "output_tokens": output_tokens,
-    }
 
 
 def extract_anthropic(record):
-    usage = usage_object(record)
-    return {
-        "input_tokens": number(usage.get("input_tokens")),
-        "cached_tokens": 0,
-        "cache_read_input_tokens": number(usage.get("cache_read_input_tokens")),
-        "cache_creation_input_tokens": number(
-            usage.get("cache_creation_input_tokens")
+    usage, prefix = usage_envelope(record)
+    return extraction(
+        input_tokens=extracted_value(usage, ("input_tokens",), prefix),
+        cache_read_input_tokens=extracted_value(
+            usage, ("cache_read_input_tokens",), prefix
         ),
-        "cache_write_tokens": 0,
-        "output_tokens": number(usage.get("output_tokens")),
-    }
+        cache_creation_input_tokens=extracted_value(
+            usage, ("cache_creation_input_tokens",), prefix
+        ),
+        output_tokens=extracted_value(usage, ("output_tokens",), prefix),
+    )
 
 
 def extract_bedrock(record):
-    metrics = bedrock_usage_object(record)
-    return {
-        "input_tokens": number(value_for(metrics, ("InputTokens", "inputTokens"))),
-        "cached_tokens": 0,
-        "cache_read_input_tokens": number(
-            value_for(
-                metrics, ("CacheReadInputTokens", "cacheReadInputTokens")
-            )
+    metrics, prefix = bedrock_usage_envelope(record)
+    return extraction(
+        input_tokens=extracted_value(
+            metrics, ("InputTokens", "inputTokens"), prefix
         ),
-        "cache_creation_input_tokens": number(
-            value_for(
-                metrics, ("CacheWriteInputTokens", "cacheWriteInputTokens")
-            )
+        cache_read_input_tokens=extracted_value(
+            metrics, ("CacheReadInputTokens", "cacheReadInputTokens"), prefix
         ),
-        "cache_write_tokens": 0,
-        "output_tokens": number(
-            value_for(metrics, ("OutputTokens", "outputTokens"))
+        cache_creation_input_tokens=extracted_value(
+            metrics, ("CacheWriteInputTokens", "cacheWriteInputTokens"), prefix
         ),
-    }
+        output_tokens=extracted_value(
+            metrics, ("OutputTokens", "outputTokens"), prefix
+        ),
+    )
 
 
 def extract_gemini_interactions(record):
-    usage = gemini_interactions_usage_object(record)
-    return {
-        "input_tokens": number(
-            value_for(usage, ("total_input_tokens", "totalInputTokens"))
+    usage, prefix = gemini_interactions_usage_envelope(record)
+    return extraction(
+        input_tokens=extracted_value(
+            usage, ("total_input_tokens", "totalInputTokens"), prefix
         ),
-        "cached_tokens": number(
-            value_for(usage, ("total_cached_tokens", "totalCachedTokens"))
+        cached_tokens=extracted_value(
+            usage, ("total_cached_tokens", "totalCachedTokens"), prefix
         ),
-        "cache_read_input_tokens": 0,
-        "cache_creation_input_tokens": 0,
-        "cache_write_tokens": 0,
-        "output_tokens": number(
-            value_for(usage, ("total_output_tokens", "totalOutputTokens"))
+        output_tokens=extracted_value(
+            usage, ("total_output_tokens", "totalOutputTokens"), prefix
         ),
-    }
+    )
 
 
 def extract_gemini_generate_content(record):
-    usage = gemini_generate_content_usage_object(record)
-    return {
-        "input_tokens": number(
-            value_for(usage, ("prompt_token_count", "promptTokenCount"))
+    usage, prefix = gemini_generate_content_usage_envelope(record)
+    return extraction(
+        input_tokens=extracted_value(
+            usage, ("prompt_token_count", "promptTokenCount"), prefix
         ),
-        "cached_tokens": number(
-            value_for(
-                usage, ("cached_content_token_count", "cachedContentTokenCount")
-            )
+        cached_tokens=extracted_value(
+            usage, ("cached_content_token_count", "cachedContentTokenCount"), prefix
         ),
-        "cache_read_input_tokens": 0,
-        "cache_creation_input_tokens": 0,
-        "cache_write_tokens": 0,
-        "output_tokens": number(
-            value_for(usage, ("candidates_token_count", "candidatesTokenCount"))
+        output_tokens=extracted_value(
+            usage, ("candidates_token_count", "candidatesTokenCount"), prefix
         ),
-    }
+    )
 
 
 def extract_unknown(record):
-    return {
-        metric: first_number(record, aliases)
-        for metric, aliases in FIELD_ALIASES.items()
-    }
+    return extraction(
+        **{
+            metric: first_number(record, aliases)
+            for metric, aliases in FIELD_ALIASES.items()
+        }
+    )
 
 
 class UsageSurfaceAdapter:
@@ -359,7 +393,7 @@ class GeminiInteractionsUsageAdapter(UsageSurfaceAdapter):
     semantics = "inclusive"
 
     def matches(self, record):
-        usage = gemini_interactions_usage_object(record)
+        usage, _ = gemini_interactions_usage_envelope(record)
         if not usage:
             return False
         provider = provider_name(record)
@@ -390,7 +424,7 @@ class GeminiGenerateContentUsageAdapter(UsageSurfaceAdapter):
         provider = provider_name(record)
         if provider and provider != self.provider:
             return False
-        return bool(gemini_generate_content_usage_object(record))
+        return bool(gemini_generate_content_usage_envelope(record)[0])
 
     def extract(self, record):
         return extract_gemini_generate_content(record)
@@ -426,23 +460,31 @@ def infer_provider(record):
     return usage_adapter_for(record).provider
 
 
-def normalize_record(record, accounting_mode=None, index=None):
-    adapter = usage_adapter_for(record)
-    row = adapter.extract(record)
-    semantics = (
-        accounting_mode
-        if adapter.semantics == "ambiguous" and accounting_mode
-        else adapter.semantics
-    )
+def inclusive_violations(row):
+    """Return inclusive cache components that cannot fit inside the input total."""
+    return [
+        field
+        for field in INCLUSIVE_CACHE_COMPONENTS
+        if row[field] > row["input_tokens"]
+    ]
 
-    cache_benefit_tokens = row["cached_tokens"] + row["cache_read_input_tokens"]
-    cache_write_total_tokens = (
-        row["cache_write_tokens"] + row["cache_creation_input_tokens"]
-    )
-    total_input_tokens = row["input_tokens"]
-    if semantics == "additive":
-        total_input_tokens += cache_benefit_tokens + cache_write_total_tokens
 
+def denominator_status(row, semantics):
+    if semantics == "ambiguous":
+        return "ambiguous"
+    if semantics == "inclusive" and inclusive_violations(row):
+        return "invalid"
+    return "valid"
+
+
+def aggregate_denominator_status(statuses):
+    for status in DENOMINATOR_PRECEDENCE:
+        if status in statuses:
+            return status
+    return "ambiguous"
+
+
+def normalization_warnings(adapter, row, semantics, index):
     warnings = []
     if semantics == "ambiguous":
         warnings.append(
@@ -468,6 +510,37 @@ def normalize_record(record, accounting_mode=None, index=None):
                         ),
                     }
                 )
+    elif semantics == "inclusive":
+        for field in inclusive_violations(row):
+            warnings.append(
+                {
+                    "code": "INCLUSIVE_CACHE_BREAKDOWN_EXCEEDS_INPUT",
+                    "index": index,
+                    "field": field,
+                    "message": (
+                        f"{field} exceeds the inclusive input token total"
+                    ),
+                }
+            )
+    return warnings
+
+
+def normalize_record(record, accounting_mode=None, index=None):
+    adapter = usage_adapter_for(record)
+    row, source_fields = adapter.extract(record)
+    semantics = (
+        accounting_mode
+        if adapter.semantics == "ambiguous" and accounting_mode
+        else adapter.semantics
+    )
+
+    cache_benefit_tokens = row["cached_tokens"] + row["cache_read_input_tokens"]
+    cache_write_total_tokens = (
+        row["cache_write_tokens"] + row["cache_creation_input_tokens"]
+    )
+    total_input_tokens = row["input_tokens"]
+    if semantics == "additive":
+        total_input_tokens += cache_benefit_tokens + cache_write_total_tokens
 
     row.update(
         {
@@ -475,7 +548,9 @@ def normalize_record(record, accounting_mode=None, index=None):
             "cache_write_total_tokens": cache_write_total_tokens,
             "total_input_tokens": total_input_tokens,
             "accounting_semantics": semantics,
-            "warnings": warnings,
+            "source_fields": source_fields,
+            "denominator_status": denominator_status(row, semantics),
+            "warnings": normalization_warnings(adapter, row, semantics, index),
         }
     )
     return row
@@ -493,6 +568,7 @@ def metadata_value(record, name):
 def normalize_event(record, index, accounting_mode=None):
     row = normalize_record(record, accounting_mode=accounting_mode, index=index)
     return {
+        "schema_version": SCHEMA_VERSION,
         "index": index,
         "provider": infer_provider(record),
         "model": metadata_value(record, "model"),
@@ -562,6 +638,9 @@ def summarize(records, accounting_mode=None):
         "output_tokens": sum(row["output_tokens"] for row in normalized),
         "warnings": [warning for row in normalized for warning in row["warnings"]],
     }
+    totals["denominator_status"] = aggregate_denominator_status(
+        {row["denominator_status"] for row in normalized}
+    )
     semantics = {row["accounting_semantics"] for row in normalized}
     totals["accounting_semantics"] = (
         next(iter(semantics)) if len(semantics) == 1 else "mixed" if semantics else "unknown"

--- a/audit-prompt-caching/scripts/render_audit_report.py
+++ b/audit-prompt-caching/scripts/render_audit_report.py
@@ -141,9 +141,9 @@ def has_extended_fields(finding):
     )
 
 
-def load_usage(path):
+def load_usage(path, accounting_mode=None):
     records = analyze_usage_logs.read_records(Path(path))
-    return analyze_usage_logs.summarize(records)
+    return analyze_usage_logs.summarize(records, accounting_mode=accounting_mode)
 
 
 def load_roi(path):
@@ -194,7 +194,7 @@ def cost_assessment(roi):
 
 
 def build_report(args):
-    usage = load_usage(args.usage_log)
+    usage = load_usage(args.usage_log, accounting_mode=args.accounting_mode)
     roi = load_roi(args.roi_json) if args.roi_json else None
     findings = [parse_finding(finding) for finding in args.finding]
     return {
@@ -224,6 +224,17 @@ def denominator_caveat(usage):
         f"Usage denominator status is {status}, so the observed cache hit ratio "
         "is non-decision-grade and must not support a savings claim. "
         "Fix usage accounting before estimating impact."
+    )
+
+
+def qualified_cost_assessment(report):
+    """Inline-qualify cost claims whose usage denominator is not decision-grade."""
+    status = report["usage"].get("denominator_status")
+    assessment = report["cost_assessment"]
+    if status not in NON_DECISION_GRADE_DENOMINATORS:
+        return assessment
+    return (
+        f"{assessment} (usage ratio non-decision-grade; denominator {status})"
     )
 
 
@@ -273,6 +284,7 @@ def expected_impact(usage, roi=None):
 
 def render_markdown(report):
     usage = report["usage"]
+    cost_assessment_line = qualified_cost_assessment(report)
     lines = [
         "# Prompt Cache Audit",
         "",
@@ -286,7 +298,7 @@ def render_markdown(report):
         f"- Cache write tokens: {usage['cache_write_total_tokens']}",
         f"- Cache write/read ratio: {usage['cache_write_read_ratio']}",
         f"- Output share: {usage['output_share']}",
-        f"- Cost impact: {report['cost_assessment']}",
+        f"- Cost impact: {cost_assessment_line}",
         f"- Measurement change: {report['measurement_change']}",
         f"- Prompt behavior change: {report['prompt_behavior_change']}",
         f"- Provider/routing change: {report['provider_routing_change']}",
@@ -366,7 +378,7 @@ def render_markdown(report):
                 f"- Cost with cache: ${roi['total_with_cache_cost']:.6f}",
                 f"- Cache read cost: ${roi['cache_read_input_cost']:.6f}",
                 f"- Cache write cost: ${roi['cache_write_input_cost']:.6f}",
-                f"- Assessment: {report['cost_assessment']}",
+                f"- Assessment: {cost_assessment_line}",
             ]
         )
     lines.extend(
@@ -391,6 +403,14 @@ def main(argv=None):
         description="Render a prompt-cache audit report from usage logs."
     )
     parser.add_argument("--usage-log", required=True, help="JSON, JSONL, or CSV usage log")
+    parser.add_argument(
+        "--accounting-mode",
+        choices=("inclusive", "additive"),
+        help=(
+            "Operator-supplied cache-token accounting for otherwise ambiguous "
+            "wrapper usage logs; it cannot override an inclusive contradiction."
+        ),
+    )
     parser.add_argument("--provider", default="unknown")
     parser.add_argument("--engine", default="unknown")
     parser.add_argument("--measurement-change", default=DEFAULT_MEASUREMENT_CHANGE)

--- a/audit-prompt-caching/scripts/render_audit_report.py
+++ b/audit-prompt-caching/scripts/render_audit_report.py
@@ -216,36 +216,59 @@ def build_report(args):
     }
 
 
+def denominator_caveat(usage):
+    status = usage.get("denominator_status")
+    if status not in NON_DECISION_GRADE_DENOMINATORS:
+        return None
+    return (
+        f"Usage denominator status is {status}, so the observed cache hit ratio "
+        "is non-decision-grade and must not support a savings claim. "
+        "Fix usage accounting before estimating impact."
+    )
+
+
+def rendered_cache_hit_ratio(usage):
+    ratio = usage.get("cache_hit_ratio", 0)
+    status = usage.get("denominator_status")
+    if status in NON_DECISION_GRADE_DENOMINATORS:
+        return f"{ratio} (non-decision-grade; denominator {status})"
+    return str(ratio)
+
+
 def expected_impact(usage, roi=None):
+    clauses = []
     if roi is not None:
         if roi["total_savings"] > 0:
-            return (
+            clauses.append(
                 f"The supplied pricing scenario estimates ${roi['total_savings']:.6f} "
                 "in savings. Validate it against provider billing."
             )
-        if roi["total_savings"] < 0:
-            return (
+        elif roi["total_savings"] < 0:
+            clauses.append(
                 f"The supplied pricing scenario estimates ${abs(roi['total_savings']):.6f} "
                 "in increased cost. Reduce cache writes or confirm the workload still benefits."
             )
-        return "The supplied pricing scenario is cost-neutral. Validate provider billing."
-    denominator_status = usage.get("denominator_status")
-    if denominator_status in NON_DECISION_GRADE_DENOMINATORS:
-        return (
-            f"Usage denominator status is {denominator_status}, so the observed cache "
-            "hit ratio is non-decision-grade and must not support a savings claim. "
-            "Fix usage accounting before estimating impact."
-        )
-    hit_ratio = usage.get("cache_hit_ratio", 0)
-    if hit_ratio:
-        return (
-            f"Observed cache benefit on {hit_ratio:.4f} of input tokens. "
-            "Validate TTFT and total cost separately before claiming savings."
-        )
-    return (
-        "No cache benefit tokens observed. Validate prefix stability, provider "
-        "support, routing, and cache read/write telemetry."
-    )
+        else:
+            clauses.append(
+                "The supplied pricing scenario is cost-neutral. Validate provider billing."
+            )
+
+    caveat = denominator_caveat(usage)
+    if caveat:
+        clauses.append(caveat)
+    elif roi is None:
+        hit_ratio = usage.get("cache_hit_ratio", 0)
+        if hit_ratio:
+            clauses.append(
+                f"Observed cache benefit on {hit_ratio:.4f} of input tokens. "
+                "Validate TTFT and total cost separately before claiming savings."
+            )
+        else:
+            clauses.append(
+                "No cache benefit tokens observed. Validate prefix stability, provider "
+                "support, routing, and cache read/write telemetry."
+            )
+    return " ".join(clauses)
 
 
 def render_markdown(report):
@@ -258,7 +281,7 @@ def render_markdown(report):
         f"- Provider/engine: {report['provider']}",
         f"- Engine/API surface: {report['engine']}",
         f"- Records reviewed: {usage['records']}",
-        f"- Cache hit ratio: {usage['cache_hit_ratio']}",
+        f"- Cache hit ratio: {rendered_cache_hit_ratio(usage)}",
         f"- Cache read tokens: {usage['cache_benefit_tokens']}",
         f"- Cache write tokens: {usage['cache_write_total_tokens']}",
         f"- Cache write/read ratio: {usage['cache_write_read_ratio']}",

--- a/audit-prompt-caching/scripts/render_audit_report.py
+++ b/audit-prompt-caching/scripts/render_audit_report.py
@@ -17,6 +17,55 @@ DEFAULT_PROVIDER_ROUTING_CHANGE = "unknown"
 DEFAULT_CONFIDENCE = "low"
 DEFAULT_DO_FIRST = "analyze usage logs and validate prefix stability"
 DEFAULT_DO_NOT_DO_YET = "make provider/routing changes without telemetry"
+CACHE_PLANES = (
+    "gateway_response",
+    "provider_prompt",
+    "engine_kv",
+    "external_kv",
+    "semantic_response",
+)
+CLINIC_DIMENSIONS = (
+    "applicability",
+    "evidence_quality",
+    "prefix_stability",
+    "usage_accounting",
+    "routing_locality",
+    "economics",
+    "isolation",
+)
+CLINIC_STATUSES = ("pass", "warning", "fail", "unknown", "not_applicable")
+DEFAULT_CLINIC_STATUS = "unknown"
+NON_DECISION_GRADE_DENOMINATORS = ("invalid", "ambiguous")
+
+
+def canonical_cache_planes(planes):
+    """Deduplicate selected planes and return them in canonical order."""
+    selected = set(planes or ())
+    return [plane for plane in CACHE_PLANES if plane in selected]
+
+
+def resolve_usage_accounting(status, denominator_status):
+    """Derive usage_accounting from the measured usage denominator status."""
+    if denominator_status not in NON_DECISION_GRADE_DENOMINATORS:
+        return status
+    if status == "pass":
+        raise ValueError(
+            "usage_accounting cannot be pass while the usage denominator_status is "
+            f"{denominator_status}"
+        )
+    if status == DEFAULT_CLINIC_STATUS:
+        return "fail" if denominator_status == "invalid" else "warning"
+    return status
+
+
+def build_clinic_summary(args, usage):
+    summary = {
+        dimension: getattr(args, dimension) for dimension in CLINIC_DIMENSIONS
+    }
+    summary["usage_accounting"] = resolve_usage_accounting(
+        summary["usage_accounting"], usage.get("denominator_status")
+    )
+    return summary
 
 
 def parse_finding(text):
@@ -154,6 +203,8 @@ def build_report(args):
         "measurement_change": args.measurement_change,
         "prompt_behavior_change": args.prompt_behavior_change,
         "provider_routing_change": args.provider_routing_change,
+        "cache_planes": canonical_cache_planes(args.cache_plane),
+        "clinic_summary": build_clinic_summary(args, usage),
         "confidence": args.confidence,
         "do_first": args.do_first,
         "do_not_do_yet": args.do_not_do_yet,
@@ -178,6 +229,13 @@ def expected_impact(usage, roi=None):
                 "in increased cost. Reduce cache writes or confirm the workload still benefits."
             )
         return "The supplied pricing scenario is cost-neutral. Validate provider billing."
+    denominator_status = usage.get("denominator_status")
+    if denominator_status in NON_DECISION_GRADE_DENOMINATORS:
+        return (
+            f"Usage denominator status is {denominator_status}, so the observed cache "
+            "hit ratio is non-decision-grade and must not support a savings claim. "
+            "Fix usage accounting before estimating impact."
+        )
     hit_ratio = usage.get("cache_hit_ratio", 0)
     if hit_ratio:
         return (
@@ -213,9 +271,22 @@ def render_markdown(report):
         f"- Do first: {report['do_first']}",
         f"- Do not do yet: {report['do_not_do_yet']}",
         "",
-        "## Findings",
+        "## Cache Clinic Summary",
         "",
+        "- Cache planes: "
+        + (", ".join(report["cache_planes"]) if report["cache_planes"] else "unknown"),
     ]
+    for dimension in CLINIC_DIMENSIONS:
+        label = dimension.replace("_", " ").capitalize()
+        lines.append(f"- {label}: {report['clinic_summary'][dimension]}")
+    lines.extend(
+        [
+            f"- Usage denominator status: {usage['denominator_status']}",
+            "",
+            "## Findings",
+            "",
+        ]
+    )
     if report["findings"]:
         for finding in report["findings"]:
             location = finding["source"] or finding["rule_id"] or "advisory"
@@ -302,6 +373,20 @@ def main(argv=None):
     parser.add_argument("--measurement-change", default=DEFAULT_MEASUREMENT_CHANGE)
     parser.add_argument("--prompt-behavior-change", default=DEFAULT_PROMPT_BEHAVIOR_CHANGE)
     parser.add_argument("--provider-routing-change", default=DEFAULT_PROVIDER_ROUTING_CHANGE)
+    parser.add_argument(
+        "--cache-plane",
+        action="append",
+        choices=list(CACHE_PLANES),
+        default=[],
+        help="Cache plane observed in the audited system; repeatable.",
+    )
+    for dimension in CLINIC_DIMENSIONS:
+        parser.add_argument(
+            f"--{dimension.replace('_', '-')}",
+            choices=list(CLINIC_STATUSES),
+            default=DEFAULT_CLINIC_STATUS,
+            help=f"Cache clinic status for {dimension.replace('_', ' ')}.",
+        )
     parser.add_argument("--confidence", default=DEFAULT_CONFIDENCE)
     parser.add_argument("--do-first", default=DEFAULT_DO_FIRST)
     parser.add_argument("--do-not-do-yet", default=DEFAULT_DO_NOT_DO_YET)

--- a/docs/superpowers/plans/2026-08-13-cache-audit-report-contract.md
+++ b/docs/superpowers/plans/2026-08-13-cache-audit-report-contract.md
@@ -1,0 +1,370 @@
+# Cache Audit Evidence Contract Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add traceable usage-field provenance, trustworthy denominator status, explicit cache planes, and a no-score Cache Clinic Summary without breaking existing analyzer/report consumers.
+
+**Architecture:** Preserve the existing small hexagonal boundary. Provider adapters are anti-corruption layers that return canonical token values plus raw-field paths and accounting semantics. `normalize_record` validates and aggregates those values into a provider-neutral event contract. `render_audit_report.py` is a presentation adapter that consumes only the canonical summary and explicit CLI conclusions. No provider-specific logic belongs in the renderer, and no new parallel normalizer is introduced.
+
+**Tech Stack:** Python 3.10+ standard library, `unittest`, JSON/JSONL fixtures, Markdown skill/reference files, plugin-eval 0.1.2.
+
+---
+
+## Task 1: Add provenance and denominator status to normalized usage
+
+**Files:**
+
+- Modify: `tests/test_prompt_cache_scripts.py:187-620`
+- Modify: `audit-prompt-caching/scripts/analyze_usage_logs.py:59-588`
+- Modify: `fixtures/expected/usage_summary_openai.json`
+
+### Step 1: Write failing analyzer contract tests
+
+Add focused tests that assert:
+
+```python
+self.assertEqual(event["schema_version"], 1)
+self.assertEqual(
+    event["source_fields"],
+    {
+        "input_tokens": "usage.input_tokens",
+        "cached_tokens": "usage.input_tokens_details.cached_tokens",
+        "cache_read_input_tokens": None,
+        "cache_creation_input_tokens": None,
+        "cache_write_tokens": None,
+        "output_tokens": "usage.output_tokens",
+    },
+)
+self.assertEqual(event["denominator_status"], "valid")
+```
+
+Cover these surfaces with their actual paths:
+
+- OpenAI Responses and Chat inclusive usage;
+- Anthropic additive usage;
+- Bedrock `metrics.InputTokens` and Converse `usage.inputTokens`;
+- Gemini Interactions stream `metadata.total_usage.*` and Generate Content `usageMetadata.*`;
+- unknown recursive wrapper fields, both ambiguous by default and valid after `--accounting-mode`;
+- an inclusive contradiction producing `denominator_status: invalid`;
+- aggregate precedence `invalid > ambiguous > valid` and empty-input ambiguity.
+
+Update the exact expected OpenAI summary fixture to include aggregate `denominator_status` only after the behavior exists.
+
+### Step 2: Run the focused tests and witness RED
+
+Run:
+
+```bash
+python3 -m unittest \
+  tests.test_prompt_cache_scripts.PromptCacheScriptsTest.test_analyze_usage_logs_can_emit_normalized_jsonl_events \
+  tests.test_prompt_cache_scripts.PromptCacheScriptsTest.test_analyze_usage_logs_marks_wrapper_accounting_ambiguous \
+  tests.test_prompt_cache_scripts.PromptCacheScriptsTest.test_analyze_usage_logs_warns_when_openai_breakdown_exceeds_input
+```
+
+Expected: FAIL because `schema_version`, `source_fields`, and `denominator_status` are absent.
+
+### Step 3: Implement path-aware extraction at the provider boundary
+
+Add small helpers rather than expanding `normalize_record`:
+
+```python
+CANONICAL_USAGE_FIELDS = (
+    "input_tokens",
+    "cached_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+    "cache_write_tokens",
+    "output_tokens",
+)
+
+
+def extracted_value(value, names, prefix):
+    for name in names:
+        if isinstance(value, dict) and name in value:
+            return number(value[name]), ".".join((*prefix, name))
+    return 0, None
+```
+
+Each adapter extraction must return both canonical values and exactly six source-path entries. Preserve the actual envelope chosen by `first_usage_envelope`; do not reconstruct a guessed path after extraction. Extend recursive unknown extraction with path-aware walking.
+
+Avoid raw-record retention and do not include values in `source_fields`.
+
+### Step 4: Implement denominator validation and aggregate precedence
+
+Use a dedicated helper with a narrow contract:
+
+```python
+def denominator_status(row, semantics):
+    if semantics == "ambiguous":
+        return "ambiguous"
+    if semantics == "inclusive" and any(
+        row[field] > row["input_tokens"]
+        for field in (
+            "cached_tokens",
+            "cache_read_input_tokens",
+            "cache_creation_input_tokens",
+            "cache_write_tokens",
+        )
+    ):
+        return "invalid"
+    return "valid"
+```
+
+Preserve `OPENAI_CACHE_BREAKDOWN_EXCEEDS_INPUT` for backward compatibility. Use a provider-neutral stable warning for an impossible inclusive breakdown on other adapters. Add `schema_version` only to normalized events, not to the aggregate summary.
+
+Aggregate status with a constant precedence map; no records means `ambiguous`.
+
+### Step 5: Run analyzer tests and witness GREEN
+
+Run:
+
+```bash
+python3 -m unittest tests/test_prompt_cache_scripts.py
+```
+
+Expected: all tests pass.
+
+### Step 6: Commit
+
+```bash
+git add audit-prompt-caching/scripts/analyze_usage_logs.py tests/test_prompt_cache_scripts.py fixtures/expected/usage_summary_openai.json
+git commit -m "feat: add usage evidence provenance"
+```
+
+## Task 2: Add cache planes and a no-score clinic report
+
+**Files:**
+
+- Modify: `tests/test_prompt_cache_scripts.py:736-990`
+- Modify: `audit-prompt-caching/scripts/render_audit_report.py:1-337`
+- Modify: `fixtures/expected/report_openai.md`
+
+### Step 1: Write failing report contract tests
+
+Add JSON and Markdown tests for:
+
+```python
+result = run_script(
+    "render_audit_report.py",
+    "--usage-log", usage_path,
+    "--cache-plane", "engine_kv",
+    "--cache-plane", "provider_prompt",
+    "--cache-plane", "provider_prompt",
+    "--applicability", "pass",
+    "--evidence-quality", "warning",
+    "--prefix-stability", "fail",
+    "--usage-accounting", "pass",
+    "--json",
+)
+```
+
+Assert canonical, deduplicated plane order and all seven dimensions. Assert Markdown includes `## Cache Clinic Summary`, renders `unknown` dimensions, and contains no `score`, `rank`, or grade field. Add CLI rejection tests for an invalid status and for `usage_accounting: pass` with ambiguous or invalid denominator evidence.
+
+Add a test that an ambiguous/invalid denominator makes `expected_impact` explicitly non-decision-grade instead of reporting the hit ratio as confirmed savings evidence.
+
+### Step 2: Run focused report tests and witness RED
+
+Run:
+
+```bash
+python3 -m unittest \
+  tests.test_prompt_cache_scripts.PromptCacheScriptsTest.test_render_audit_report_outputs_markdown_from_usage_fixture \
+  tests.test_prompt_cache_scripts.PromptCacheScriptsTest.test_render_audit_report_outputs_json_from_usage_fixture
+```
+
+Expected: FAIL on missing CLI arguments and report fields.
+
+### Step 3: Implement provider-neutral report helpers
+
+Define constants and small helpers:
+
+```python
+CACHE_PLANES = (
+    "gateway_response",
+    "provider_prompt",
+    "engine_kv",
+    "external_kv",
+    "semantic_response",
+)
+CLINIC_DIMENSIONS = (
+    "applicability",
+    "evidence_quality",
+    "prefix_stability",
+    "usage_accounting",
+    "routing_locality",
+    "economics",
+    "isolation",
+)
+CLINIC_STATUSES = ("pass", "warning", "fail", "unknown", "not_applicable")
+```
+
+- Canonicalize planes by filtering `CACHE_PLANES`, not by preserving arbitrary CLI order.
+- Initialize every clinic dimension to `unknown`.
+- If denominator is `invalid` and usage accounting is unknown, resolve it to `fail`.
+- If denominator is `ambiguous` and usage accounting is unknown, resolve it to `warning`.
+- Reject an explicit `pass` for ambiguous or invalid evidence with `ValueError` so `argparse` exits 2.
+- Do not derive any other clinic dimension.
+
+Do not import provider names or inspect raw records in the renderer.
+
+### Step 4: Render the new sections without an aggregate score
+
+Add `cache_planes` and `clinic_summary` to JSON. In Markdown, render cache planes and all seven dimensions before findings. Render `Cache planes: unknown` when the list is empty.
+
+Update `expected_impact` so ambiguous or invalid denominators block decision-grade hit-rate wording even when a numeric ratio exists.
+
+### Step 5: Run report tests and witness GREEN
+
+Run:
+
+```bash
+python3 -m unittest tests/test_prompt_cache_scripts.py
+```
+
+Expected: all tests pass.
+
+### Step 6: Commit
+
+```bash
+git add audit-prompt-caching/scripts/render_audit_report.py tests/test_prompt_cache_scripts.py fixtures/expected/report_openai.md
+git commit -m "feat: add cache clinic report contract"
+```
+
+## Task 3: Rewrite the skill contract with progressive disclosure
+
+**Files:**
+
+- Modify: `tests/test_prompt_cache_scripts.py:1560-1945`
+- Modify: `audit-prompt-caching/evals/evals.json`
+- Modify: `audit-prompt-caching/SKILL.md:1-309`
+- Modify: `audit-prompt-caching/references/observability.md`
+- Modify: `audit-prompt-caching/references/report-template.md`
+- Modify: `README.md`
+
+### Step 1: Write failing pressure-scenario tests
+
+Add repository tests that require the combined skill, references, and evals to contain:
+
+- all five cache planes and the instruction to identify in-scope planes;
+- `schema_version`, `source_fields`, and `denominator_status` contract terms;
+- the seven clinic dimensions and the explicit prohibition on an aggregate score;
+- a stable-prefix plan based on rendered payload evidence, not assumed provider serialization;
+- passive isolation reporting and no unauthorized active cross-tenant probes.
+
+Add at least three eval pressure scenarios:
+
+1. gateway response cache success but provider prompt-cache miss — must separate planes;
+2. high numeric hit ratio from an unknown wrapper — must mark denominator/evidence ambiguous and avoid a savings claim;
+3. incomplete audit evidence — must show unknown clinic dimensions and no aggregate score.
+
+Add a frontmatter budget test that calls plugin-eval only in the final verification, not in every unittest. The unittest should instead assert the description is concise and preserves the positive/negative trigger phrases already protected by existing tests.
+
+### Step 2: Run the new tests and witness RED
+
+Run:
+
+```bash
+python3 -m unittest tests/test_prompt_cache_scripts.py
+```
+
+Expected: FAIL because the cache-plane, evidence-contract, and clinic-summary instructions are absent.
+
+### Step 3: Make the smallest skill rewrite
+
+Shorten the frontmatter description to at most 139 plugin-eval estimated tokens while preserving current trigger behavior.
+
+In `SKILL.md`:
+
+- add one compact cache-plane gate near applicability;
+- add provenance/denominator evidence to the usage-analysis script description and quality bar;
+- add the Cache Clinic Summary to output contracts;
+- remove or consolidate repeated wording so invocation tokens do not exceed the 5,852-token baseline.
+
+Put the detailed canonical event fields in `references/observability.md` and the detailed plane/status rendering contract in `references/report-template.md`. Do not add a new reference file.
+
+Update README examples to demonstrate explicit `--cache-plane` and clinic status use without claiming an aggregate score.
+
+### Step 4: Run package behavior checks and witness GREEN
+
+Run:
+
+```bash
+python3 -m unittest tests/test_prompt_cache_scripts.py
+python3 audit-prompt-caching/scripts/validate_skill_package.py audit-prompt-caching
+python3 audit-prompt-caching/scripts/run_trigger_eval.py audit-prompt-caching
+```
+
+Expected: all tests pass; package and trigger eval report `status: ok`.
+
+### Step 5: Commit
+
+```bash
+git add audit-prompt-caching/SKILL.md audit-prompt-caching/references/observability.md audit-prompt-caching/references/report-template.md audit-prompt-caching/evals/evals.json README.md tests/test_prompt_cache_scripts.py
+git commit -m "docs: define cache audit evidence workflow"
+```
+
+## Task 4: Compare static evaluation and complete verification
+
+**Files:**
+
+- Modify if needed: implementation files from Tasks 1-3
+- Generate: `docs/superpowers/specs/2026-08-13-plugin-eval-after.json`
+- Generate: `docs/superpowers/specs/2026-08-13-plugin-eval-after.md`
+- Generate: `docs/superpowers/specs/2026-08-13-plugin-eval-compare.md`
+
+### Step 1: Run plugin-eval after implementation
+
+Run:
+
+```bash
+node /Users/notevskii/.codex/plugins/cache/openai-curated-remote/plugin-eval/0.1.2/scripts/plugin-eval.js \
+  analyze audit-prompt-caching --format json \
+  --output docs/superpowers/specs/2026-08-13-plugin-eval-after.json
+node /Users/notevskii/.codex/plugins/cache/openai-curated-remote/plugin-eval/0.1.2/scripts/plugin-eval.js \
+  analyze audit-prompt-caching --format markdown \
+  --output docs/superpowers/specs/2026-08-13-plugin-eval-after.md
+node /Users/notevskii/.codex/plugins/cache/openai-curated-remote/plugin-eval/0.1.2/scripts/plugin-eval.js \
+  compare docs/superpowers/specs/2026-08-13-plugin-eval-before.json \
+  docs/superpowers/specs/2026-08-13-plugin-eval-after.json \
+  --format markdown \
+  --output docs/superpowers/specs/2026-08-13-plugin-eval-compare.md
+```
+
+Expected: trigger estimate leaves the excessive band; invoked-skill estimate does not exceed 5,852 tokens. Any deferred-token increase is reported rather than hidden. The package-local test warning may remain and must be labeled as a layout heuristic, not a real missing-test defect.
+
+### Step 2: Run full fresh verification
+
+Run:
+
+```bash
+python3 -m unittest tests/test_prompt_cache_scripts.py
+python3 audit-prompt-caching/scripts/validate_skill_package.py audit-prompt-caching
+python3 audit-prompt-caching/scripts/run_trigger_eval.py audit-prompt-caching
+python3 - <<'PY'
+from pathlib import Path
+for path in [*Path('audit-prompt-caching/scripts').glob('*.py'), *Path('tests').glob('*.py')]:
+    compile(path.read_text(), str(path), 'exec')
+    print(f'ok {path}')
+PY
+git diff --check
+find . -name __pycache__ -type d -prune -exec rm -rf {} +
+find . \( -name __pycache__ -o -name '*.pyc' \) -print
+```
+
+Expected: all commands pass; the final `find` prints nothing.
+
+### Step 3: Review the final branch
+
+Perform two independent reviews against the design spec:
+
+1. spec compliance — every acceptance criterion implemented, no out-of-scope active integration;
+2. code quality — backward compatibility, provider math, source-path accuracy, CLI failure behavior, and complexity.
+
+Fix all critical and important findings with a new RED/GREEN test before claiming completion.
+
+### Step 4: Commit durable review artifacts
+
+```bash
+git add docs/superpowers/specs docs/superpowers/plans/2026-08-13-cache-audit-report-contract.md
+git commit -m "docs: record cache audit contract evaluation"
+```

--- a/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-design.md
+++ b/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-design.md
@@ -1,0 +1,289 @@
+# Cache Audit Evidence Contract and Clinic Summary
+
+**Status:** Reviewed — revision 1  
+**Date:** 2026-08-13  
+**Target:** `audit-prompt-caching` skill package
+
+## Context
+
+The skill already detects prompt-cache applicability, prefix instability, provider usage accounting, routing-locality problems, and cache ROI. Its scripts normalize several provider usage envelopes and render a decision-first report. The missing piece is a stable evidence contract that tells a reviewer:
+
+1. which raw fields produced each normalized value;
+2. whether the cache-hit denominator is valid, ambiguous, or contradicted by the evidence;
+3. which cache planes are actually in scope;
+4. which audit dimensions are confirmed, degraded, failed, or still unknown.
+
+Without that contract, correct provider-specific adapters can still produce an apparently precise percentage whose provenance or denominator is unclear. Reports also risk collapsing response caching, provider prompt caching, engine KV reuse, external KV storage, and semantic response caching into one generic "cache" diagnosis.
+
+## Decision
+
+Extend the existing usage normalizer and report renderer with additive, backward-compatible fields. Do not introduce a second normalizer, a runtime integration layer, or an aggregate health score.
+
+The implementation follows a small hexagonal boundary:
+
+```text
+Provider usage envelope
+        |
+        v
+Provider adapter / anti-corruption layer
+        |
+        v
+Canonical normalized usage event
+        |
+        +--------------------+
+        |                    |
+        v                    v
+JSONL output          Aggregate summary
+                             |
+                             v
+                  Markdown / JSON report adapter
+```
+
+The provider adapters own raw-field extraction and accounting semantics. The canonical event owns provider-neutral evidence. The report renderer consumes canonical summaries and explicit operator inputs; it must not reinterpret raw provider envelopes.
+
+## Goals
+
+- Make normalized usage values traceable to raw JSON paths without retaining prompt content or copying raw records.
+- Make denominator quality explicit and deterministic.
+- Represent the cache stack as independently selectable planes.
+- Add a no-score Cache Clinic Summary with per-dimension statuses.
+- Preserve all existing CLI commands and existing JSON keys.
+- Keep scripts Python-stdlib-only and usable on exported files without network access.
+- Keep the trigger surface below plugin-eval's current excessive band and avoid increasing the invoked `SKILL.md` budget.
+
+## Non-goals
+
+- A new standalone usage-normalization script.
+- Direct provider, gateway, Grafana, or tracing API integrations.
+- Active timing, concurrency, warm-up, or security probes.
+- Automatic cache warm-up or cache invalidation.
+- Logging raw prompts, tool outputs, credentials, or complete provider envelopes.
+- A universal claim about hidden provider-side serialization order.
+- A numeric or letter-grade score that hides missing evidence.
+- A large package or directory refactor.
+- Moving or duplicating the repository test suite to satisfy a package-local static heuristic.
+- Broad provider-reference pruning without provider-specific regression evidence.
+
+## Architectural boundaries
+
+### Core domain
+
+`normalize_record` and the aggregate summary define the provider-neutral domain contract. Domain values use canonical names such as `input_tokens`, `cache_read_input_tokens`, and `cache_write_input_tokens`.
+
+The domain layer may depend on Python standard-library types. It must not depend on the report renderer, filesystem layout beyond the CLI boundary, or provider SDKs.
+
+### Provider adapters
+
+Each existing usage adapter remains an anti-corruption layer around one provider usage surface. It owns:
+
+- recognized envelope shapes;
+- canonical-field extraction;
+- raw JSON-path provenance;
+- inclusive, additive, or ambiguous accounting semantics;
+- provider-specific invariants that can invalidate a denominator.
+
+Adding a provider surface should require a new adapter or a narrow extension to an existing adapter, not provider conditionals in the report renderer.
+
+Adapters return canonical values and provenance through small, named extraction helpers. Denominator validation is a separate helper from field extraction and aggregation. New behavior must not be folded into the existing long provider-policy branches or add a new high-complexity function.
+
+### Driving and presentation adapters
+
+The existing command-line interfaces are the driving adapters. JSONL and JSON are machine-facing presentation adapters; Markdown is the human-facing presentation adapter.
+
+`render_audit_report.py` may consume the analyzer's canonical summary helpers. `analyze_usage_logs.py` must never import the renderer. This dependency direction is the only structural constraint required for the current package size.
+
+## Canonical normalized usage event
+
+Every event emitted by `analyze_usage_logs.py --normalized-jsonl` adds the following fields:
+
+```json
+{
+  "schema_version": 1,
+  "source_fields": {
+    "input_tokens": "usage.prompt_tokens",
+    "cached_tokens": "usage.prompt_tokens_details.cached_tokens",
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "cache_write_tokens": null,
+    "output_tokens": "usage.completion_tokens"
+  },
+  "accounting_semantics": "inclusive",
+  "denominator_status": "valid",
+  "warnings": []
+}
+```
+
+Rules:
+
+- `schema_version` identifies this event contract, not the raw provider schema.
+- `source_fields` contains exactly the six directly extracted canonical usage field names: `input_tokens`, `cached_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `cache_write_tokens`, and `output_tokens`. Values are raw JSON paths selected by the adapter, or `null` when the canonical value is absent or derived without a direct source field.
+- Paths describe field locations only. They must never contain field values.
+- Existing canonical numeric fields remain unchanged.
+- Existing `warnings` remains the canonical list of normalization warnings; do not add a duplicate `normalization_warnings` key.
+- Existing `accounting_semantics` remains `inclusive`, `additive`, or `ambiguous`.
+
+### Denominator status
+
+`denominator_status` is one of:
+
+- `valid`: accounting semantics are known and all adapter invariants required for the cache-hit denominator pass;
+- `ambiguous`: accounting semantics remain unresolved, normally for an unknown wrapper without an explicit override;
+- `invalid`: a known adapter invariant is contradicted, for example cached input exceeds an inclusive total-input field.
+
+The aggregate summary uses the worst observed status:
+
+```text
+invalid > ambiguous > valid
+```
+
+An empty input set has `denominator_status: ambiguous`, because no measured denominator exists.
+
+The analyzer may still emit token totals for ambiguous or invalid records. Any cache-hit percentage derived from them must be treated as non-decision-grade evidence by the renderer and documented as such.
+
+### Backward compatibility
+
+- No existing normalized event key is removed or renamed.
+- No existing summary key is removed or renamed.
+- The default text output keeps its current structure unless a new section is explicitly required below.
+- Existing consumers that ignore unknown JSON keys continue to work.
+
+## Cache-plane taxonomy
+
+The report supports a repeatable `--cache-plane` argument with these canonical values, rendered in this order regardless of input order:
+
+1. `gateway_response` — exact or policy-based response reuse at a gateway or proxy;
+2. `provider_prompt` — provider-managed prompt or prefix caching reported by provider usage telemetry;
+3. `engine_kv` — reuse of attention KV state inside a self-hosted inference engine;
+4. `external_kv` — KV blocks persisted or transferred outside the serving process;
+5. `semantic_response` — similarity-based retrieval of a prior response.
+
+The JSON report adds `cache_planes` as a deduplicated list. If no plane is supplied, the list is empty and Markdown renders `Cache planes: unknown`. The renderer must not infer a plane from a model name, route, or usage field.
+
+This taxonomy is a stack, not a mutually exclusive classification: one audit may involve several planes. Findings and recommendations should name the affected plane whenever the evidence supports it.
+
+## Cache Clinic Summary
+
+The renderer adds `clinic_summary` to JSON and a `## Cache Clinic Summary` section to Markdown. It contains these dimensions:
+
+- `applicability`
+- `evidence_quality`
+- `prefix_stability`
+- `usage_accounting`
+- `routing_locality`
+- `economics`
+- `isolation`
+
+Each dimension has exactly one status:
+
+- `pass`
+- `warning`
+- `fail`
+- `unknown`
+- `not_applicable`
+
+All statuses default to `unknown`. The CLI accepts one optional argument per dimension, for example `--usage-accounting warning`. Invalid values fail through `argparse` with exit status 2.
+
+The report never computes an aggregate score, rank, percentage, or traffic-light summary from these dimensions. A missing dimension remains visible as `unknown` instead of being excluded from a denominator.
+
+For this increment, statuses are explicit operator conclusions. Automatic derivation is allowed only where an unambiguous invariant already exists:
+
+- aggregate denominator `invalid` may force `usage_accounting: fail`;
+- aggregate denominator `ambiguous` may force `usage_accounting: warning` only when the operator left it `unknown`;
+- no other dimension is inferred from filenames, provider names, or report prose.
+
+Explicit operator input cannot mark an ambiguous or invalid denominator as `pass`; contradictory input is rejected with a clear error.
+
+`evidence_quality` remains explicit even though it is not automatically derived in this increment. It captures whether conclusions rest on rendered payloads, normalized telemetry, routing evidence, or only hypotheses. Leaving it `unknown` is preferable to silently excluding evidence quality from the summary.
+
+## Prefix-plan evidence boundary
+
+The skill may recommend a stable-prefix plan only from an observed rendered request or a clearly identified request-construction boundary. The plan should separate:
+
+- stable instructions and tool definitions;
+- bounded semi-stable context;
+- request-specific history and user input.
+
+It must describe ordering as an observed application payload property. It must not claim a universal provider-internal serialization order without cited provider evidence.
+
+## Warm-up, concurrency, and isolation boundary
+
+Existing cold-fanout and routing-locality checks remain diagnostic decision guidance. This change may surface their conclusions in the Cache Clinic Summary, but it does not add an active load generator, timing probe, cache warmer, or security scanner.
+
+Isolation reporting is passive and evidence-based. It may document cache-key scope, tenant boundaries, credential boundaries, and redaction risks visible in configuration or traces. Active cross-tenant probes require separate authorization and are out of scope.
+
+## Failure behavior
+
+- Malformed JSON and unsupported record shapes retain current fail-fast behavior.
+- Unknown provider wrappers remain `accounting_semantics: ambiguous` unless the existing accounting override resolves them.
+- Known impossible inclusive accounting produces `denominator_status: invalid` and a stable warning code.
+- Missing optional source fields use `null`; they do not cause invented paths.
+- Reports with no normalized usage evidence show the denominator and clinic dimensions as unknown rather than zero or pass.
+
+## Security and privacy
+
+- Store field paths, never raw usage envelopes, prompt text, tool payloads, API keys, headers, or response bodies.
+- Keep normalized JSONL safe for offline review under the same handling policy as existing token telemetry.
+- Do not turn on active provider calls or cross-tenant probes.
+- Recommendations involving shared-cache isolation must distinguish confirmed configuration from hypotheses.
+
+## Skill instruction budget
+
+The skill entrypoint uses progressive disclosure:
+
+- shorten the frontmatter description to at most 139 estimated plugin-eval tokens while retaining positive and negative trigger boundaries;
+- do not increase the estimated token count of `SKILL.md` from the 5,852-token baseline;
+- consolidate repeated workflow wording instead of appending a second audit workflow;
+- put detailed usage provenance and report-field contracts into existing `references/observability.md` and `references/report-template.md`;
+- do not add a new reference file unless those existing boundaries are insufficient.
+
+The package's deferred-token total is tracked as a no-regression signal, not optimized by deleting provider references or duplicating tests. Static plugin-eval results must be labeled as estimates until observed benchmark traces are supplied.
+
+## Acceptance criteria
+
+### Analyzer contract
+
+- OpenAI inclusive usage emits exact source paths and a valid denominator when cached input does not exceed prompt input.
+- Anthropic additive usage emits exact read/write/input paths and a valid denominator.
+- Bedrock raw lower-camel and Pascal-case usage surfaces preserve their actual source paths.
+- Gemini Interactions and Generate Content surfaces preserve their distinct source paths.
+- An unknown wrapper without an override is ambiguous; the existing accounting override can make it valid.
+- A known inclusive contradiction is invalid and carries a stable warning.
+- Aggregate denominator status follows `invalid > ambiguous > valid` and is ambiguous for no records.
+
+### Report contract
+
+- JSON and Markdown render selected cache planes deterministically and do not infer missing planes.
+- JSON and Markdown render all seven clinic dimensions, including unknown values.
+- Invalid clinic statuses fail through the CLI.
+- Invalid accounting cannot be rendered as a passing usage-accounting dimension.
+- Neither JSON nor Markdown contains an aggregate clinic score.
+- Existing decision summary, usage, ROI, and finding contracts remain present.
+
+### Skill behavior
+
+- The skill explicitly distinguishes the five cache planes and asks which are in scope.
+- The skill uses provenance and denominator status before treating a hit rate as decision-grade.
+- The skill produces per-dimension statuses without an aggregate score.
+- The skill preserves the existing decision-first workflow and provider-specific references.
+- The shortened trigger still activates on prompt-cache telemetry, prefix-stability, request-shape, routing-locality, and self-hosted KV-reuse problems, and still excludes generic prompt writing and unrelated performance work.
+
+### Verification
+
+- Script behavior changes are implemented test-first with a witnessed RED state.
+- `python3 -m unittest tests/test_prompt_cache_scripts.py` passes.
+- Package validation and trigger evaluation pass.
+- All Python files compile.
+- `git diff --check` passes and no generated bytecode remains.
+- Before/after plugin-eval JSON reports are compared; static budget deltas are reported separately from behavioral correctness.
+
+## Rollout and compatibility risks
+
+The change is additive but can expose previously hidden ambiguity. A report that formerly showed a percentage may now label its denominator ambiguous or invalid. That is an intentional evidence-quality correction, not a telemetry regression.
+
+The primary compatibility risk is downstream strict-schema validation of normalized JSONL. `schema_version` and additive keys make the contract explicit, but strict consumers still need to allow new fields. No migration is required for consumers that ignore unknown keys.
+
+## Resolved review questions
+
+1. Version normalized events now. Add independent aggregate or report versions only when those contracts need a breaking migration.
+2. Reject `usage_accounting: pass` for both ambiguous and invalid denominators.
+3. Keep all seven clinic dimensions. `evidence_quality` is explicit and defaults to `unknown` until stronger derivation rules exist.

--- a/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-design.md
+++ b/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-design.md
@@ -1,7 +1,7 @@
 # Cache Audit Evidence Contract and Clinic Summary
 
-**Status:** Reviewed — revision 1  
-**Date:** 2026-08-13  
+**Status:** Reviewed — revision 1
+**Date:** 2026-08-13
 **Target:** `audit-prompt-caching` skill package
 
 ## Context

--- a/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-design.md
+++ b/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-design.md
@@ -1,6 +1,6 @@
 # Cache Audit Evidence Contract and Clinic Summary
 
-**Status:** Reviewed — revision 1
+**Status:** Implemented and verified
 **Date:** 2026-08-13
 **Target:** `audit-prompt-caching` skill package
 
@@ -215,9 +215,9 @@ Isolation reporting is passive and evidence-based. It may document cache-key sco
 
 - Malformed JSON and unsupported record shapes retain current fail-fast behavior.
 - Unknown provider wrappers remain `accounting_semantics: ambiguous` unless the existing accounting override resolves them.
-- Known impossible inclusive accounting produces `denominator_status: invalid` and a stable warning code.
+- Known impossible inclusive accounting, including aggregate cache benefit/write totals above the inclusive input total, produces `denominator_status: invalid` and a stable warning code.
 - Missing optional source fields use `null`; they do not cause invented paths.
-- Reports with no normalized usage evidence show the denominator and clinic dimensions as unknown rather than zero or pass.
+- Reports with no normalized usage evidence show an ambiguous denominator, derive `usage_accounting: warning`, leave the other unproven clinic dimensions `unknown`, and qualify the numeric ratio as non-decision-grade.
 
 ## Security and privacy
 
@@ -247,7 +247,7 @@ The package's deferred-token total is tracked as a no-regression signal, not opt
 - Bedrock raw lower-camel and Pascal-case usage surfaces preserve their actual source paths.
 - Gemini Interactions and Generate Content surfaces preserve their distinct source paths.
 - An unknown wrapper without an override is ambiguous; the existing accounting override can make it valid.
-- A known inclusive contradiction is invalid and carries a stable warning.
+- A known inclusive component or aggregate contradiction is invalid and carries a stable warning.
 - Aggregate denominator status follows `invalid > ambiguous > valid` and is ambiguous for no records.
 
 ### Report contract

--- a/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-design.md
+++ b/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-design.md
@@ -94,7 +94,7 @@ The existing command-line interfaces are the driving adapters. JSONL and JSON ar
 
 ## Canonical normalized usage event
 
-Every event emitted by `analyze_usage_logs.py --normalized-jsonl` adds the following fields:
+Every event emitted by `analyze_usage_logs.py --jsonl-normalized` adds the following fields:
 
 ```json
 {

--- a/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-implementation-review.md
+++ b/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-implementation-review.md
@@ -1,0 +1,64 @@
+# Cache Audit Evidence Contract: Implementation Review
+
+**Date:** 2026-08-13
+**Branch:** `codex/cache-audit-report-contract`
+**Baseline:** `origin/main` at `6346ac9`
+
+## Outcome
+
+Implemented and verified. The vertical slice adds field-level usage provenance, denominator trust status, explicit cache-plane selection, and a seven-dimension Cache Clinic Summary without a roll-up score. Existing CLI arguments and existing JSON keys remain available.
+
+## Delivered behavior
+
+- Provider adapters emit exact `source_fields` paths for OpenAI, Anthropic, Bedrock, Gemini, and unknown wrappers.
+- Normalized events carry `schema_version: 1`; summaries and events carry `denominator_status`.
+- Inclusive accounting validates individual and aggregate cache benefit/write totals. Ambiguous or invalid evidence is never presented as a decision-grade hit ratio.
+- `render_audit_report.py` accepts repeatable cache planes, all seven clinic statuses, and the existing inclusive/additive accounting override.
+- Markdown qualifies hit ratio and both cost lines when usage evidence is ambiguous or invalid. Operator-supplied ROI remains visible but cannot silently launder the usage ratio.
+- Skill instructions separate five cache planes, require observed-payload evidence for prefix plans, keep isolation review passive, and leave unproven clinic dimensions visible as `unknown`.
+
+## Review loop
+
+Claude Opus agents implemented the analyzer, renderer, and skill-contract increments through the local Consilium. Independent Claude reviews found and drove fixes for:
+
+1. evidence-free records incorrectly marked valid;
+2. unqualified invalid hit ratios and ROI short-circuiting;
+3. missing renderer accounting override and unqualified cost-summary lines;
+4. removed trigger anchors after instruction compression;
+5. aggregate inclusive aliases producing a decision-grade ratio above 100%.
+
+The final post-fix review confirmed the earlier integration gaps were closed. Its remaining blocking aggregate-invariant finding was fixed in `fa91919` and covered by analyzer and renderer tests.
+
+## Plugin-eval comparison
+
+| Metric | Before | After | Delta |
+|---|---:|---:|---:|
+| Score | 54 | 68 | +14 |
+| Grade | F | D | +1 band |
+| Trigger tokens | 170 | 135 | -35 |
+| Invoke tokens | 5,852 | 5,850 | -2 |
+| Deferred tokens | 37,740 | 41,238 | +3,498 |
+
+One budget failure was removed and no new failure was introduced. The deferred increase is the cost of new production code, provider-pressure tests, and detailed existing-reference contracts. It is reported as a trade-off, not hidden.
+
+The remaining static warnings are not release blockers for this vertical slice:
+
+- package-local test discovery misses the repository's root `tests/` suite;
+- complexity is dominated by existing script paths and is not a new provider-contract defect;
+- no observed runtime usage benchmark was supplied, so token conclusions remain static estimates.
+
+## Verification evidence
+
+- Unit suite: 131 tests pass.
+- Package validator: `status: ok`.
+- Trigger eval inventory: 24 cases, 16 positive and 8 negative, `status: ok`.
+- Official plugin-eval comparison: score +14, no new failures.
+- Python syntax compilation: pass.
+- `git diff --check`: pass.
+- Generated `__pycache__` and `.pyc`: none remain after final cleanup.
+
+## Deferred follow-ups
+
+- Run an observed-usage benchmark on representative audit prompts before claiming runtime token or latency savings.
+- Consider a future pre-computed summary input for the renderer to reduce analyzer/presentation coupling.
+- Treat broader scanner redaction and malformed-input hardening as separate security work; neither is required to deliver this evidence-contract increment.

--- a/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-plugin-eval-review.md
+++ b/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-plugin-eval-review.md
@@ -1,0 +1,51 @@
+# Plugin-eval Review: Cache Audit Evidence Contract
+
+**Date:** 2026-08-13  
+**Target revision:** draft `2026-08-13-cache-audit-report-contract-design.md`  
+**Evaluator:** plugin-eval 0.1.2, static analysis only
+
+## Outcome
+
+Proceed with the evidence-contract vertical slice, but constrain its instruction and code footprint. The functional proposal addresses gaps that plugin-eval does not score directly; plugin-eval mainly exposed existing budget and maintainability pressure that the implementation must not amplify.
+
+Baseline result: **54/100, grade F, high risk**.
+
+## Confirmed findings
+
+| Finding | Evidence | Decision for this change |
+|---|---|---|
+| Trigger text is excessive | 170 estimated trigger tokens; plugin-eval heavy ceiling is 164 and moderate ceiling is 139 | Shorten frontmatter description to at most 139 estimated tokens while retaining positive and negative trigger boundaries |
+| Invoked skill text is heavy | 5,852 estimated tokens in `SKILL.md` | Add no long workflow section; consolidate existing repeated guidance and route detailed contracts to existing references |
+| Deferred package text is excessive | 37,740 estimated tokens across references, scripts, and evals | Do not add a new reference unless an existing reference cannot hold the contract; avoid broad provider-reference pruning in this feature because it could change provider behavior without dedicated verification |
+| Existing Python complexity is high | maximum static cyclomatic complexity 99 and maximum function length 118 | Keep new normalization and report logic in small helpers; do not refactor unrelated GPT-5.6 lint logic inside this vertical slice |
+| No observed usage supplied | static estimates only | Treat token conclusions as estimates; define a later benchmark path instead of claiming runtime savings |
+
+## Tooling limitations and rejected score-chasing
+
+Plugin-eval reported zero Python test files because the evaluation target is `audit-prompt-caching/`, while the repository intentionally keeps its unittest suite at `tests/test_prompt_cache_scripts.py`. Baseline verification ran 81 passing tests. Moving or duplicating that suite under the package solely to satisfy the evaluator would create two sources of truth and conflicts with the repository layout, so this warning is documented but not implemented.
+
+The deferred-token score counts executable scripts, fixtures, evals, and provider references as one static budget. Those files are selectively loaded or executed by the skill. A broad deletion could improve the score while reducing provider correctness. This feature therefore applies a no-regression guardrail and leaves provider-reference consolidation to a separately benchmarked change.
+
+The supplied `improve-skill` workflow points to `/Users/benlesh/.codex/skills/skill-creator/SKILL.md`, which is not available in this environment. The local `superpowers:writing-skills` instructions are used as the equivalent skill-authoring gate: concise trigger surface, progressive disclosure, pressure scenarios, and RED/GREEN verification.
+
+## Specification changes required
+
+1. Add explicit static-budget guardrails for the frontmatter and main `SKILL.md`.
+2. Require small extraction/validation helpers so provenance work does not expand existing complex functions.
+3. Keep the event schema version local to normalized events; defer independent aggregate/report versioning until a breaking change needs it.
+4. Reject `usage_accounting: pass` for both ambiguous and invalid denominators.
+5. Keep `evidence_quality` as an explicit dimension because it prevents a technically successful cache signal from hiding weak evidence; default it to `unknown`.
+6. Add before/after plugin-eval comparison to verification, while stating that it remains static unless a benchmark supplies observed traces.
+
+## Rewrite brief
+
+Implement the vertical slice without creating a parallel normalization path. Provider adapters return canonical values plus exact source paths and accounting semantics. A small denominator validator assigns `valid`, `ambiguous`, or `invalid`. The report renderer accepts explicit cache planes and seven clinic statuses, derives only the usage-accounting guardrail from denominator evidence, and never computes an aggregate score.
+
+Keep the skill entrypoint compact: shorten the trigger description, consolidate repeated diagnostic wording, and put detailed telemetry contracts into the existing observability/report references. Add pressure scenarios that prove the skill asks which cache plane is in scope, refuses decision-grade hit rates with ambiguous denominators, and leaves unknown clinic dimensions visible.
+
+## Measurement plan
+
+- Static: compare plugin-eval before/after JSON reports and inspect trigger, invocation, and deferred token deltas.
+- Behavioral: run the package trigger eval and repository unit suite.
+- Outcome: use pressure scenarios for cache-plane separation, denominator trust, and no-score reporting.
+- Runtime follow-up: benchmark representative audit prompts with observed usage only in a separate authorized run; no live provider usage is available in this review.

--- a/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-plugin-eval-review.md
+++ b/docs/superpowers/specs/2026-08-13-cache-audit-report-contract-plugin-eval-review.md
@@ -1,7 +1,7 @@
 # Plugin-eval Review: Cache Audit Evidence Contract
 
-**Date:** 2026-08-13  
-**Target revision:** draft `2026-08-13-cache-audit-report-contract-design.md`  
+**Date:** 2026-08-13
+**Target revision:** draft `2026-08-13-cache-audit-report-contract-design.md`
 **Evaluator:** plugin-eval 0.1.2, static analysis only
 
 ## Outcome

--- a/docs/superpowers/specs/2026-08-13-plugin-eval-after.json
+++ b/docs/superpowers/specs/2026-08-13-plugin-eval-after.json
@@ -1,0 +1,1723 @@
+{
+  "schemaVersion": 1,
+  "tool": {
+    "name": "plugin-eval",
+    "version": "0.1.0"
+  },
+  "createdAt": "2026-08-12T23:21:45.385Z",
+  "target": {
+    "kind": "skill",
+    "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+    "entryPath": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+    "name": "audit-prompt-caching",
+    "relativePath": "audit-prompt-caching"
+  },
+  "summary": {
+    "score": 68,
+    "grade": "D",
+    "riskLevel": "high",
+    "riskReasons": [
+      "Contains 1 failing error check (deferred_cost_tokens-budget-high).",
+      "Overall score is below 70, which the evaluator treats as high risk."
+    ],
+    "scoreBreakdown": {
+      "startingScore": 100,
+      "totalDeductions": 32.25,
+      "finalScore": 68,
+      "gradeThresholds": {
+        "A": 93,
+        "B": 85,
+        "C": 70,
+        "D": 55
+      }
+    },
+    "checkCounts": {
+      "total": 6,
+      "pass": 0,
+      "warn": 4,
+      "fail": 1,
+      "info": 2,
+      "error": 1,
+      "warning": 4
+    },
+    "deductions": [
+      {
+        "id": "deferred_cost_tokens-budget-high",
+        "category": "budget",
+        "severity": "error",
+        "status": "fail",
+        "message": "deferred_cost_tokens is excessive relative to the current Codex baseline.",
+        "penalty": 14,
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ],
+        "source": "core"
+      },
+      {
+        "id": "invoke_cost_tokens-budget-high",
+        "category": "budget",
+        "severity": "warning",
+        "status": "warn",
+        "message": "invoke_cost_tokens is heavy relative to the current Codex baseline.",
+        "penalty": 4.5,
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ],
+        "source": "core"
+      },
+      {
+        "id": "py-complexity-high",
+        "category": "complexity",
+        "severity": "warning",
+        "status": "warn",
+        "message": "At least one Python function has high cyclomatic complexity.",
+        "penalty": 4.5,
+        "remediation": [
+          "Split complex functions into smaller helpers or guard clauses."
+        ],
+        "source": "core"
+      },
+      {
+        "id": "py-function-length-high",
+        "category": "readability",
+        "severity": "warning",
+        "status": "warn",
+        "message": "At least one Python function is long enough to hurt readability.",
+        "penalty": 4.5,
+        "remediation": [
+          "Break large functions into smaller helpers with clear names."
+        ],
+        "source": "core"
+      },
+      {
+        "id": "py-tests-missing",
+        "category": "best-practice",
+        "severity": "warning",
+        "status": "warn",
+        "message": "Python source files were found without matching test files.",
+        "penalty": 4.5,
+        "remediation": [
+          "Add `test_*.py` or `tests/` coverage for the main Python logic."
+        ],
+        "source": "core"
+      },
+      {
+        "id": "coverage-artifacts-unavailable",
+        "category": "coverage",
+        "severity": "info",
+        "status": "info",
+        "message": "No coverage artifacts were found for this target.",
+        "penalty": 0.25,
+        "remediation": [
+          "Generate `lcov.info`, `coverage.xml`, or an Istanbul coverage JSON file if you want coverage scoring."
+        ],
+        "source": "core"
+      }
+    ],
+    "categoryDeductions": [
+      {
+        "category": "budget",
+        "totalPenalty": 18.5,
+        "checks": 2
+      },
+      {
+        "category": "best-practice",
+        "totalPenalty": 4.5,
+        "checks": 1
+      },
+      {
+        "category": "complexity",
+        "totalPenalty": 4.5,
+        "checks": 1
+      },
+      {
+        "category": "readability",
+        "totalPenalty": 4.5,
+        "checks": 1
+      },
+      {
+        "category": "coverage",
+        "totalPenalty": 0.25,
+        "checks": 1
+      }
+    ],
+    "topRecommendations": [
+      "Reduce repeated instruction text and move detail into deferred supporting files.",
+      "Split complex functions into smaller helpers or guard clauses.",
+      "Break large functions into smaller helpers with clear names.",
+      "Add `test_*.py` or `tests/` coverage for the main Python logic."
+    ],
+    "whyBullets": [
+      "1 failing error check are driving the highest-confidence problems.",
+      "4 warning signals still need cleanup before this feels polished.",
+      "budget is the largest source of score loss at -18.5 points.",
+      "Active budget pressure is high enough that token cost may dominate the user experience.",
+      "No observed usage is attached yet, so budget conclusions are still based on static estimates."
+    ],
+    "fixFirst": [
+      {
+        "id": "deferred_cost_tokens-budget-high",
+        "category": "budget",
+        "severity": "error",
+        "status": "fail",
+        "message": "deferred_cost_tokens is excessive relative to the current Codex baseline.",
+        "why": "Budget pressure matters because always-loaded or frequently-loaded text can make the workflow feel expensive fast.",
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ],
+        "penalty": 14,
+        "source": "core"
+      },
+      {
+        "id": "invoke_cost_tokens-budget-high",
+        "category": "budget",
+        "severity": "warning",
+        "status": "warn",
+        "message": "invoke_cost_tokens is heavy relative to the current Codex baseline.",
+        "why": "Budget pressure matters because always-loaded or frequently-loaded text can make the workflow feel expensive fast.",
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ],
+        "penalty": 4.5,
+        "source": "core"
+      },
+      {
+        "id": "py-tests-missing",
+        "category": "best-practice",
+        "severity": "warning",
+        "status": "warn",
+        "message": "Python source files were found without matching test files.",
+        "why": "Best-practice gaps usually do not break the workflow immediately, but they make the skill harder to understand and improve.",
+        "remediation": [
+          "Add `test_*.py` or `tests/` coverage for the main Python logic."
+        ],
+        "penalty": 4.5,
+        "source": "core"
+      }
+    ],
+    "watchNext": [
+      {
+        "id": "py-complexity-high",
+        "category": "complexity",
+        "severity": "warning",
+        "status": "warn",
+        "message": "At least one Python function has high cyclomatic complexity.",
+        "why": "Complexity findings matter because they increase review cost and make generated or helper code harder to change safely.",
+        "remediation": [
+          "Split complex functions into smaller helpers or guard clauses."
+        ],
+        "penalty": 4.5,
+        "source": "core"
+      },
+      {
+        "id": "py-function-length-high",
+        "category": "readability",
+        "severity": "warning",
+        "status": "warn",
+        "message": "At least one Python function is long enough to hurt readability.",
+        "why": "Readability issues slow engineers down during review, debugging, and follow-up edits.",
+        "remediation": [
+          "Break large functions into smaller helpers with clear names."
+        ],
+        "penalty": 4.5,
+        "source": "core"
+      }
+    ]
+  },
+  "budgets": {
+    "method": "estimated-static",
+    "invocation_policy": {
+      "allow_implicit_invocation": true,
+      "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/agents/openai.yaml"
+    },
+    "trigger_cost_tokens": {
+      "value": 135,
+      "band": "moderate",
+      "thresholds": {
+        "goodMax": 96,
+        "moderateMax": 139,
+        "heavyMax": 164
+      },
+      "components": [
+        {
+          "label": "skill-name",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+          "tokens": 5,
+          "note": "Always-loaded skill identifier"
+        },
+        {
+          "label": "skill-description",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+          "tokens": 130,
+          "note": "Always-loaded trigger description"
+        }
+      ]
+    },
+    "invoke_cost_tokens": {
+      "value": 5850,
+      "band": "heavy",
+      "thresholds": {
+        "goodMax": 1380,
+        "moderateMax": 2039,
+        "heavyMax": 6905
+      },
+      "components": [
+        {
+          "label": "skill-file",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+          "tokens": 5850,
+          "note": "Loaded when the skill is invoked"
+        }
+      ]
+    },
+    "deferred_cost_tokens": {
+      "value": 41238,
+      "band": "excessive",
+      "thresholds": {
+        "goodMax": 3771,
+        "moderateMax": 17846,
+        "heavyMax": 26574
+      },
+      "components": [
+        {
+          "label": "agents/openai.yaml",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/agents/openai.yaml",
+          "tokens": 65,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "evals/evals.json",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/evals/evals.json",
+          "tokens": 1564,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "evals/trigger_eval.json",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/evals/trigger_eval.json",
+          "tokens": 774,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/agent-tools.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/agent-tools.md",
+          "tokens": 2125,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/anthropic.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/anthropic.md",
+          "tokens": 951,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/azure-openai.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/azure-openai.md",
+          "tokens": 1011,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/bedrock.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/bedrock.md",
+          "tokens": 521,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/deepseek.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/deepseek.md",
+          "tokens": 721,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/economics.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/economics.md",
+          "tokens": 407,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/gemini.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/gemini.md",
+          "tokens": 1169,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/mastra.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/mastra.md",
+          "tokens": 614,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/mechanics.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/mechanics.md",
+          "tokens": 672,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/observability.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/observability.md",
+          "tokens": 1062,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/openai.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/openai.md",
+          "tokens": 1972,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/openrouter.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/openrouter.md",
+          "tokens": 820,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/operational-playbook.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/operational-playbook.md",
+          "tokens": 574,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/predeploy-checklist.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/predeploy-checklist.md",
+          "tokens": 422,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/qwen.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/qwen.md",
+          "tokens": 962,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/report-template.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/report-template.md",
+          "tokens": 829,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/rules.json",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/rules.json",
+          "tokens": 1257,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/sglang.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/sglang.md",
+          "tokens": 984,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/use-cases.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/use-cases.md",
+          "tokens": 699,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/vercel-ai-sdk.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/vercel-ai-sdk.md",
+          "tokens": 863,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/vllm.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/vllm.md",
+          "tokens": 859,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/yandexgpt.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/yandexgpt.md",
+          "tokens": 671,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/zai.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/zai.md",
+          "tokens": 671,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/analyze_usage_logs.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/analyze_usage_logs.py",
+          "tokens": 5673,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/estimate_cache_roi.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/estimate_cache_roi.py",
+          "tokens": 1495,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/extract_llm_calls.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/extract_llm_calls.py",
+          "tokens": 1143,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/layout_linter.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/layout_linter.py",
+          "tokens": 3263,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/prefix_stability_check.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/prefix_stability_check.py",
+          "tokens": 866,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/render_audit_report.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/render_audit_report.py",
+          "tokens": 4067,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/run_trigger_eval.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/run_trigger_eval.py",
+          "tokens": 603,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/validate_skill_package.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/validate_skill_package.py",
+          "tokens": 889,
+          "note": "Deferred supporting file"
+        }
+      ]
+    },
+    "total_tokens": {
+      "value": 47223,
+      "band": "excessive"
+    }
+  },
+  "observedUsage": null,
+  "checks": [
+    {
+      "id": "invoke_cost_tokens-budget-high",
+      "category": "budget",
+      "severity": "warning",
+      "status": "warn",
+      "message": "invoke_cost_tokens is heavy relative to the current Codex baseline.",
+      "evidence": [
+        "Value: 5850 tokens",
+        "Baseline samples: skills=12, plugins=176"
+      ],
+      "remediation": [
+        "Reduce repeated instruction text and move detail into deferred supporting files."
+      ],
+      "source": "core"
+    },
+    {
+      "id": "deferred_cost_tokens-budget-high",
+      "category": "budget",
+      "severity": "error",
+      "status": "fail",
+      "message": "deferred_cost_tokens is excessive relative to the current Codex baseline.",
+      "evidence": [
+        "Value: 41238 tokens",
+        "Baseline samples: skills=12, plugins=176"
+      ],
+      "remediation": [
+        "Reduce repeated instruction text and move detail into deferred supporting files."
+      ],
+      "source": "core"
+    },
+    {
+      "id": "py-complexity-high",
+      "category": "complexity",
+      "severity": "warning",
+      "status": "warn",
+      "message": "At least one Python function has high cyclomatic complexity.",
+      "evidence": [
+        "Max complexity: 124"
+      ],
+      "remediation": [
+        "Split complex functions into smaller helpers or guard clauses."
+      ],
+      "source": "core"
+    },
+    {
+      "id": "py-function-length-high",
+      "category": "readability",
+      "severity": "warning",
+      "status": "warn",
+      "message": "At least one Python function is long enough to hurt readability.",
+      "evidence": [
+        "Max function length: 118 lines"
+      ],
+      "remediation": [
+        "Break large functions into smaller helpers with clear names."
+      ],
+      "source": "core"
+    },
+    {
+      "id": "py-tests-missing",
+      "category": "best-practice",
+      "severity": "warning",
+      "status": "warn",
+      "message": "Python source files were found without matching test files.",
+      "evidence": [
+        "Source files: 8"
+      ],
+      "remediation": [
+        "Add `test_*.py` or `tests/` coverage for the main Python logic."
+      ],
+      "source": "core"
+    },
+    {
+      "id": "coverage-artifacts-unavailable",
+      "category": "coverage",
+      "severity": "info",
+      "status": "info",
+      "message": "No coverage artifacts were found for this target.",
+      "evidence": [
+        "audit-prompt-caching"
+      ],
+      "remediation": [
+        "Generate `lcov.info`, `coverage.xml`, or an Istanbul coverage JSON file if you want coverage scoring."
+      ],
+      "source": "core"
+    }
+  ],
+  "metrics": [
+    {
+      "id": "skill_line_count",
+      "category": "budget",
+      "value": 307,
+      "unit": "lines",
+      "band": "good",
+      "source": "core",
+      "targetPath": "audit-prompt-caching"
+    },
+    {
+      "id": "description_length_chars",
+      "category": "budget",
+      "value": 517,
+      "unit": "chars",
+      "band": "moderate",
+      "source": "core",
+      "targetPath": "audit-prompt-caching"
+    },
+    {
+      "id": "relative_link_count",
+      "category": "documentation",
+      "value": 0,
+      "unit": "links",
+      "band": "good",
+      "source": "core",
+      "targetPath": "audit-prompt-caching"
+    },
+    {
+      "id": "code_fence_count",
+      "category": "readability",
+      "value": 1,
+      "unit": "blocks",
+      "band": "good",
+      "source": "core",
+      "targetPath": "audit-prompt-caching"
+    },
+    {
+      "id": "support_file_count",
+      "category": "documentation",
+      "value": 34,
+      "unit": "files",
+      "band": "good",
+      "source": "core",
+      "targetPath": "audit-prompt-caching"
+    },
+    {
+      "id": "trigger_cost_tokens",
+      "category": "budget",
+      "value": 135,
+      "unit": "tokens",
+      "band": "moderate",
+      "source": "core"
+    },
+    {
+      "id": "invoke_cost_tokens",
+      "category": "budget",
+      "value": 5850,
+      "unit": "tokens",
+      "band": "heavy",
+      "source": "core"
+    },
+    {
+      "id": "deferred_cost_tokens",
+      "category": "budget",
+      "value": 41238,
+      "unit": "tokens",
+      "band": "excessive",
+      "source": "core"
+    },
+    {
+      "id": "py_file_count",
+      "category": "code-quality",
+      "value": 8,
+      "unit": "files",
+      "band": "good",
+      "source": "core"
+    },
+    {
+      "id": "py_function_count",
+      "category": "code-quality",
+      "value": 111,
+      "unit": "functions",
+      "band": "good",
+      "source": "core"
+    },
+    {
+      "id": "py_max_cyclomatic_complexity",
+      "category": "complexity",
+      "value": 124,
+      "unit": "score",
+      "band": "heavy",
+      "source": "core"
+    },
+    {
+      "id": "py_average_function_length",
+      "category": "readability",
+      "value": 14.77,
+      "unit": "lines",
+      "band": "good",
+      "source": "core"
+    },
+    {
+      "id": "py_max_nesting_depth",
+      "category": "complexity",
+      "value": 8,
+      "unit": "levels",
+      "band": "heavy",
+      "source": "core"
+    },
+    {
+      "id": "py_comment_ratio",
+      "category": "readability",
+      "value": 0.005,
+      "unit": "ratio",
+      "band": "moderate",
+      "source": "core"
+    },
+    {
+      "id": "py_test_file_count",
+      "category": "best-practice",
+      "value": 0,
+      "unit": "files",
+      "band": "moderate",
+      "source": "core"
+    },
+    {
+      "id": "coverage_artifact_count",
+      "category": "coverage",
+      "value": 0,
+      "unit": "files",
+      "band": "info",
+      "source": "core"
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "skill-link-inventory",
+      "type": "inventory",
+      "label": "Skill relative links",
+      "description": "Relative links found in SKILL.md.",
+      "source": "core",
+      "data": {
+        "links": []
+      }
+    },
+    {
+      "id": "budget-breakdown",
+      "type": "budget",
+      "label": "Budget breakdown",
+      "description": "Trigger, invoke, and deferred token budget analysis.",
+      "source": "core",
+      "data": {
+        "budgets": {
+          "method": "estimated-static",
+          "invocation_policy": {
+            "allow_implicit_invocation": true,
+            "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/agents/openai.yaml"
+          },
+          "trigger_cost_tokens": {
+            "value": 135,
+            "band": "moderate",
+            "thresholds": {
+              "goodMax": 96,
+              "moderateMax": 139,
+              "heavyMax": 164
+            },
+            "components": [
+              {
+                "label": "skill-name",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+                "tokens": 5,
+                "note": "Always-loaded skill identifier"
+              },
+              {
+                "label": "skill-description",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+                "tokens": 130,
+                "note": "Always-loaded trigger description"
+              }
+            ]
+          },
+          "invoke_cost_tokens": {
+            "value": 5850,
+            "band": "heavy",
+            "thresholds": {
+              "goodMax": 1380,
+              "moderateMax": 2039,
+              "heavyMax": 6905
+            },
+            "components": [
+              {
+                "label": "skill-file",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+                "tokens": 5850,
+                "note": "Loaded when the skill is invoked"
+              }
+            ]
+          },
+          "deferred_cost_tokens": {
+            "value": 41238,
+            "band": "excessive",
+            "thresholds": {
+              "goodMax": 3771,
+              "moderateMax": 17846,
+              "heavyMax": 26574
+            },
+            "components": [
+              {
+                "label": "agents/openai.yaml",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/agents/openai.yaml",
+                "tokens": 65,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "evals/evals.json",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/evals/evals.json",
+                "tokens": 1564,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "evals/trigger_eval.json",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/evals/trigger_eval.json",
+                "tokens": 774,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/agent-tools.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/agent-tools.md",
+                "tokens": 2125,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/anthropic.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/anthropic.md",
+                "tokens": 951,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/azure-openai.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/azure-openai.md",
+                "tokens": 1011,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/bedrock.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/bedrock.md",
+                "tokens": 521,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/deepseek.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/deepseek.md",
+                "tokens": 721,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/economics.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/economics.md",
+                "tokens": 407,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/gemini.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/gemini.md",
+                "tokens": 1169,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/mastra.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/mastra.md",
+                "tokens": 614,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/mechanics.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/mechanics.md",
+                "tokens": 672,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/observability.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/observability.md",
+                "tokens": 1062,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/openai.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/openai.md",
+                "tokens": 1972,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/openrouter.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/openrouter.md",
+                "tokens": 820,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/operational-playbook.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/operational-playbook.md",
+                "tokens": 574,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/predeploy-checklist.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/predeploy-checklist.md",
+                "tokens": 422,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/qwen.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/qwen.md",
+                "tokens": 962,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/report-template.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/report-template.md",
+                "tokens": 829,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/rules.json",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/rules.json",
+                "tokens": 1257,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/sglang.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/sglang.md",
+                "tokens": 984,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/use-cases.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/use-cases.md",
+                "tokens": 699,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/vercel-ai-sdk.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/vercel-ai-sdk.md",
+                "tokens": 863,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/vllm.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/vllm.md",
+                "tokens": 859,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/yandexgpt.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/yandexgpt.md",
+                "tokens": 671,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/zai.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/zai.md",
+                "tokens": 671,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/analyze_usage_logs.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/analyze_usage_logs.py",
+                "tokens": 5673,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/estimate_cache_roi.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/estimate_cache_roi.py",
+                "tokens": 1495,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/extract_llm_calls.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/extract_llm_calls.py",
+                "tokens": 1143,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/layout_linter.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/layout_linter.py",
+                "tokens": 3263,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/prefix_stability_check.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/prefix_stability_check.py",
+                "tokens": 866,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/render_audit_report.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/render_audit_report.py",
+                "tokens": 4067,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/run_trigger_eval.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/run_trigger_eval.py",
+                "tokens": 603,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/validate_skill_package.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/validate_skill_package.py",
+                "tokens": 889,
+                "note": "Deferred supporting file"
+              }
+            ]
+          },
+          "total_tokens": {
+            "value": 47223,
+            "band": "excessive"
+          }
+        },
+        "baselineEvidence": {
+          "skillSamples": 12,
+          "pluginSamples": 176,
+          "sourceRoots": [
+            "../../../../../.codex/skills",
+            "../../../../../.codex/plugins/cache/openai-curated",
+            "../../../../../.codex/.tmp/plugins/plugins"
+          ]
+        }
+      }
+    },
+    {
+      "id": "py-per-file-analysis",
+      "type": "analysis",
+      "label": "Python per-file analysis",
+      "description": "Heuristic Python quality and complexity breakdown by file.",
+      "source": "core",
+      "data": {
+        "files": [
+          {
+            "path": "scripts/analyze_usage_logs.py",
+            "functionCount": 55,
+            "complexity": 124,
+            "maxFunctionLength": 53,
+            "maxNesting": 6,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/estimate_cache_roi.py",
+            "functionCount": 6,
+            "complexity": 23,
+            "maxFunctionLength": 74,
+            "maxNesting": 4,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/extract_llm_calls.py",
+            "functionCount": 4,
+            "complexity": 18,
+            "maxFunctionLength": 33,
+            "maxNesting": 8,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/layout_linter.py",
+            "functionCount": 18,
+            "complexity": 99,
+            "maxFunctionLength": 118,
+            "maxNesting": 5,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/prefix_stability_check.py",
+            "functionCount": 5,
+            "complexity": 18,
+            "maxFunctionLength": 50,
+            "maxNesting": 3,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/render_audit_report.py",
+            "functionCount": 15,
+            "complexity": 69,
+            "maxFunctionLength": 114,
+            "maxNesting": 7,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/run_trigger_eval.py",
+            "functionCount": 3,
+            "complexity": 22,
+            "maxFunctionLength": 28,
+            "maxNesting": 3,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/validate_skill_package.py",
+            "functionCount": 5,
+            "complexity": 27,
+            "maxFunctionLength": 51,
+            "maxNesting": 3,
+            "longLines": 0
+          }
+        ]
+      }
+    },
+    {
+      "id": "measurement-plan",
+      "type": "measurement-plan",
+      "label": "Measurement plan",
+      "description": "Recommended toolsets for measuring the real-world effect of this skill or plugin.",
+      "source": "core",
+      "data": {
+        "recommendedToolsets": [
+          "token-usage-observer",
+          "task-outcome-scorecard",
+          "latency-efficiency"
+        ],
+        "toolsets": [
+          {
+            "id": "token-usage-observer",
+            "label": "Token Usage Observer",
+            "priority": "high",
+            "goal": "Measure how many tokens the skill or plugin actually burns in representative runs.",
+            "why": "Static estimates are useful guardrails, but observed usage is what tells you whether a real workflow is affordable and whether caching or reasoning changes the picture.",
+            "signals": [
+              "observed_usage_sample_count",
+              "observed_input_tokens_avg",
+              "observed_total_tokens_avg",
+              "estimate_vs_observed_input_ratio"
+            ],
+            "evidenceSources": [
+              "Responses API usage logs",
+              "Codex-like session exports",
+              "JSONL traces captured from local benchmarking harnesses"
+            ],
+            "starterPack": {
+              "manifestName": "token-usage-pack",
+              "focus": "Validate sample size, cold-start versus warm-cache behavior, and estimate drift over time."
+            }
+          },
+          {
+            "id": "task-outcome-scorecard",
+            "label": "Task Outcome Scorecard",
+            "priority": "high",
+            "goal": "Measure whether the skill helps users finish the intended job with fewer retries and less cleanup.",
+            "why": "A low-token skill is still a miss if it fails the task, and a verbose skill may be worth it if it consistently improves first-pass success.",
+            "signals": [
+              "task_success_rate",
+              "first_pass_success_rate",
+              "retry_rate",
+              "human_override_rate"
+            ],
+            "evidenceSources": [
+              "Task run logs",
+              "Structured user acceptance checklist",
+              "Before/after comparison runs on the same prompts"
+            ],
+            "starterPack": {
+              "manifestName": "task-outcomes-pack",
+              "focus": "Score success, retries, and manual intervention across a fixed prompt set."
+            }
+          },
+          {
+            "id": "tool-call-audit",
+            "label": "Tool Call Audit",
+            "priority": "medium",
+            "goal": "Check whether the agent uses the right tools, arguments, and sequencing when the skill is active.",
+            "why": "For Codex plugins and many higher-agency skills, tool correctness is often the real determinant of user value.",
+            "signals": [
+              "tool_call_success_rate",
+              "invalid_tool_argument_rate",
+              "recoverable_tool_failure_rate"
+            ],
+            "evidenceSources": [
+              "Tool invocation traces",
+              "Recorded sessions",
+              "Golden-path scenario replays"
+            ],
+            "starterPack": {
+              "manifestName": "tool-audit-pack",
+              "focus": "Flag wrong tool selection, malformed args, and missing follow-up calls."
+            }
+          },
+          {
+            "id": "latency-efficiency",
+            "label": "Latency And Efficiency",
+            "priority": "high",
+            "goal": "Track whether the skill speeds users up enough to justify its cost.",
+            "why": "DX improvements usually win when they reduce waiting or rework, not only when they reduce absolute token counts.",
+            "signals": [
+              "p50_time_to_first_acceptable_answer_seconds",
+              "p95_time_to_task_completion_seconds",
+              "tokens_per_successful_run"
+            ],
+            "evidenceSources": [
+              "Benchmark harness timings",
+              "Manual stopwatch runs on canonical tasks",
+              "Responses API timestamps combined with usage logs"
+            ],
+            "starterPack": {
+              "manifestName": "latency-efficiency-pack",
+              "focus": "Measure time-to-value and cost-per-success on a stable prompt suite."
+            }
+          },
+          {
+            "id": "human-rubric-review",
+            "label": "Human Rubric Review",
+            "priority": "medium",
+            "goal": "Capture clarity, trust, and usefulness signals that automated checks will miss.",
+            "why": "The best skills often reduce confusion and editing effort in ways that do not show up in static lint-like checks.",
+            "signals": [
+              "clarity_score_avg",
+              "confidence_score_avg",
+              "follow_up_question_rate"
+            ],
+            "evidenceSources": [
+              "Reviewer scorecards",
+              "Team rubric sheets",
+              "Annotated transcripts"
+            ],
+            "starterPack": {
+              "manifestName": "human-rubric-pack",
+              "focus": "Collect 1 to 5 scores for clarity, trust, and edit burden across a small evaluator panel."
+            }
+          },
+          {
+            "id": "regression-suite",
+            "label": "Regression Suite",
+            "priority": "medium",
+            "goal": "Protect the repository behavior that the skill is supposed to improve.",
+            "why": "If a skill is meant to help coding workflows, outcomes should be paired with deterministic repo checks so quality gains do not come from cutting corners.",
+            "signals": [
+              "test_pass_rate",
+              "lint_pass_rate",
+              "regression_escape_count"
+            ],
+            "evidenceSources": [
+              "Unit and integration test runs",
+              "Coverage deltas",
+              "Snapshot or golden-file checks"
+            ],
+            "starterPack": {
+              "manifestName": "regression-pack",
+              "focus": "Blend repository test outcomes with evaluation-task success metrics."
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "extensions": [],
+  "measurementPlan": {
+    "kind": "measurement-plan",
+    "createdAt": "2026-08-12T23:21:46.497Z",
+    "target": {
+      "kind": "skill",
+      "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+      "entryPath": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+      "name": "audit-prompt-caching",
+      "relativePath": "audit-prompt-caching"
+    },
+    "title": "Measurement plan for audit-prompt-caching",
+    "summary": "Combine cost, outcome, and trust signals so you can tell whether the skill or plugin is genuinely helping instead of only looking well-structured on paper.",
+    "recommendedToolsets": [
+      "token-usage-observer",
+      "task-outcome-scorecard",
+      "latency-efficiency"
+    ],
+    "toolsets": [
+      {
+        "id": "token-usage-observer",
+        "label": "Token Usage Observer",
+        "priority": "high",
+        "goal": "Measure how many tokens the skill or plugin actually burns in representative runs.",
+        "why": "Static estimates are useful guardrails, but observed usage is what tells you whether a real workflow is affordable and whether caching or reasoning changes the picture.",
+        "signals": [
+          "observed_usage_sample_count",
+          "observed_input_tokens_avg",
+          "observed_total_tokens_avg",
+          "estimate_vs_observed_input_ratio"
+        ],
+        "evidenceSources": [
+          "Responses API usage logs",
+          "Codex-like session exports",
+          "JSONL traces captured from local benchmarking harnesses"
+        ],
+        "starterPack": {
+          "manifestName": "token-usage-pack",
+          "focus": "Validate sample size, cold-start versus warm-cache behavior, and estimate drift over time."
+        }
+      },
+      {
+        "id": "task-outcome-scorecard",
+        "label": "Task Outcome Scorecard",
+        "priority": "high",
+        "goal": "Measure whether the skill helps users finish the intended job with fewer retries and less cleanup.",
+        "why": "A low-token skill is still a miss if it fails the task, and a verbose skill may be worth it if it consistently improves first-pass success.",
+        "signals": [
+          "task_success_rate",
+          "first_pass_success_rate",
+          "retry_rate",
+          "human_override_rate"
+        ],
+        "evidenceSources": [
+          "Task run logs",
+          "Structured user acceptance checklist",
+          "Before/after comparison runs on the same prompts"
+        ],
+        "starterPack": {
+          "manifestName": "task-outcomes-pack",
+          "focus": "Score success, retries, and manual intervention across a fixed prompt set."
+        }
+      },
+      {
+        "id": "tool-call-audit",
+        "label": "Tool Call Audit",
+        "priority": "medium",
+        "goal": "Check whether the agent uses the right tools, arguments, and sequencing when the skill is active.",
+        "why": "For Codex plugins and many higher-agency skills, tool correctness is often the real determinant of user value.",
+        "signals": [
+          "tool_call_success_rate",
+          "invalid_tool_argument_rate",
+          "recoverable_tool_failure_rate"
+        ],
+        "evidenceSources": [
+          "Tool invocation traces",
+          "Recorded sessions",
+          "Golden-path scenario replays"
+        ],
+        "starterPack": {
+          "manifestName": "tool-audit-pack",
+          "focus": "Flag wrong tool selection, malformed args, and missing follow-up calls."
+        }
+      },
+      {
+        "id": "latency-efficiency",
+        "label": "Latency And Efficiency",
+        "priority": "high",
+        "goal": "Track whether the skill speeds users up enough to justify its cost.",
+        "why": "DX improvements usually win when they reduce waiting or rework, not only when they reduce absolute token counts.",
+        "signals": [
+          "p50_time_to_first_acceptable_answer_seconds",
+          "p95_time_to_task_completion_seconds",
+          "tokens_per_successful_run"
+        ],
+        "evidenceSources": [
+          "Benchmark harness timings",
+          "Manual stopwatch runs on canonical tasks",
+          "Responses API timestamps combined with usage logs"
+        ],
+        "starterPack": {
+          "manifestName": "latency-efficiency-pack",
+          "focus": "Measure time-to-value and cost-per-success on a stable prompt suite."
+        }
+      },
+      {
+        "id": "human-rubric-review",
+        "label": "Human Rubric Review",
+        "priority": "medium",
+        "goal": "Capture clarity, trust, and usefulness signals that automated checks will miss.",
+        "why": "The best skills often reduce confusion and editing effort in ways that do not show up in static lint-like checks.",
+        "signals": [
+          "clarity_score_avg",
+          "confidence_score_avg",
+          "follow_up_question_rate"
+        ],
+        "evidenceSources": [
+          "Reviewer scorecards",
+          "Team rubric sheets",
+          "Annotated transcripts"
+        ],
+        "starterPack": {
+          "manifestName": "human-rubric-pack",
+          "focus": "Collect 1 to 5 scores for clarity, trust, and edit burden across a small evaluator panel."
+        }
+      },
+      {
+        "id": "regression-suite",
+        "label": "Regression Suite",
+        "priority": "medium",
+        "goal": "Protect the repository behavior that the skill is supposed to improve.",
+        "why": "If a skill is meant to help coding workflows, outcomes should be paired with deterministic repo checks so quality gains do not come from cutting corners.",
+        "signals": [
+          "test_pass_rate",
+          "lint_pass_rate",
+          "regression_escape_count"
+        ],
+        "evidenceSources": [
+          "Unit and integration test runs",
+          "Coverage deltas",
+          "Snapshot or golden-file checks"
+        ],
+        "starterPack": {
+          "manifestName": "regression-pack",
+          "focus": "Blend repository test outcomes with evaluation-task success metrics."
+        }
+      }
+    ],
+    "artifact": {
+      "id": "measurement-plan",
+      "type": "measurement-plan",
+      "label": "Measurement plan",
+      "description": "Recommended toolsets for measuring the real-world effect of this skill or plugin.",
+      "source": "core",
+      "data": {
+        "recommendedToolsets": [
+          "token-usage-observer",
+          "task-outcome-scorecard",
+          "latency-efficiency"
+        ],
+        "toolsets": [
+          {
+            "id": "token-usage-observer",
+            "label": "Token Usage Observer",
+            "priority": "high",
+            "goal": "Measure how many tokens the skill or plugin actually burns in representative runs.",
+            "why": "Static estimates are useful guardrails, but observed usage is what tells you whether a real workflow is affordable and whether caching or reasoning changes the picture.",
+            "signals": [
+              "observed_usage_sample_count",
+              "observed_input_tokens_avg",
+              "observed_total_tokens_avg",
+              "estimate_vs_observed_input_ratio"
+            ],
+            "evidenceSources": [
+              "Responses API usage logs",
+              "Codex-like session exports",
+              "JSONL traces captured from local benchmarking harnesses"
+            ],
+            "starterPack": {
+              "manifestName": "token-usage-pack",
+              "focus": "Validate sample size, cold-start versus warm-cache behavior, and estimate drift over time."
+            }
+          },
+          {
+            "id": "task-outcome-scorecard",
+            "label": "Task Outcome Scorecard",
+            "priority": "high",
+            "goal": "Measure whether the skill helps users finish the intended job with fewer retries and less cleanup.",
+            "why": "A low-token skill is still a miss if it fails the task, and a verbose skill may be worth it if it consistently improves first-pass success.",
+            "signals": [
+              "task_success_rate",
+              "first_pass_success_rate",
+              "retry_rate",
+              "human_override_rate"
+            ],
+            "evidenceSources": [
+              "Task run logs",
+              "Structured user acceptance checklist",
+              "Before/after comparison runs on the same prompts"
+            ],
+            "starterPack": {
+              "manifestName": "task-outcomes-pack",
+              "focus": "Score success, retries, and manual intervention across a fixed prompt set."
+            }
+          },
+          {
+            "id": "tool-call-audit",
+            "label": "Tool Call Audit",
+            "priority": "medium",
+            "goal": "Check whether the agent uses the right tools, arguments, and sequencing when the skill is active.",
+            "why": "For Codex plugins and many higher-agency skills, tool correctness is often the real determinant of user value.",
+            "signals": [
+              "tool_call_success_rate",
+              "invalid_tool_argument_rate",
+              "recoverable_tool_failure_rate"
+            ],
+            "evidenceSources": [
+              "Tool invocation traces",
+              "Recorded sessions",
+              "Golden-path scenario replays"
+            ],
+            "starterPack": {
+              "manifestName": "tool-audit-pack",
+              "focus": "Flag wrong tool selection, malformed args, and missing follow-up calls."
+            }
+          },
+          {
+            "id": "latency-efficiency",
+            "label": "Latency And Efficiency",
+            "priority": "high",
+            "goal": "Track whether the skill speeds users up enough to justify its cost.",
+            "why": "DX improvements usually win when they reduce waiting or rework, not only when they reduce absolute token counts.",
+            "signals": [
+              "p50_time_to_first_acceptable_answer_seconds",
+              "p95_time_to_task_completion_seconds",
+              "tokens_per_successful_run"
+            ],
+            "evidenceSources": [
+              "Benchmark harness timings",
+              "Manual stopwatch runs on canonical tasks",
+              "Responses API timestamps combined with usage logs"
+            ],
+            "starterPack": {
+              "manifestName": "latency-efficiency-pack",
+              "focus": "Measure time-to-value and cost-per-success on a stable prompt suite."
+            }
+          },
+          {
+            "id": "human-rubric-review",
+            "label": "Human Rubric Review",
+            "priority": "medium",
+            "goal": "Capture clarity, trust, and usefulness signals that automated checks will miss.",
+            "why": "The best skills often reduce confusion and editing effort in ways that do not show up in static lint-like checks.",
+            "signals": [
+              "clarity_score_avg",
+              "confidence_score_avg",
+              "follow_up_question_rate"
+            ],
+            "evidenceSources": [
+              "Reviewer scorecards",
+              "Team rubric sheets",
+              "Annotated transcripts"
+            ],
+            "starterPack": {
+              "manifestName": "human-rubric-pack",
+              "focus": "Collect 1 to 5 scores for clarity, trust, and edit burden across a small evaluator panel."
+            }
+          },
+          {
+            "id": "regression-suite",
+            "label": "Regression Suite",
+            "priority": "medium",
+            "goal": "Protect the repository behavior that the skill is supposed to improve.",
+            "why": "If a skill is meant to help coding workflows, outcomes should be paired with deterministic repo checks so quality gains do not come from cutting corners.",
+            "signals": [
+              "test_pass_rate",
+              "lint_pass_rate",
+              "regression_escape_count"
+            ],
+            "evidenceSources": [
+              "Unit and integration test runs",
+              "Coverage deltas",
+              "Snapshot or golden-file checks"
+            ],
+            "starterPack": {
+              "manifestName": "regression-pack",
+              "focus": "Blend repository test outcomes with evaluation-task success metrics."
+            }
+          }
+        ]
+      }
+    },
+    "nextAction": {
+      "label": "Start with Token Usage Observer",
+      "why": "Measure how many tokens the skill or plugin actually burns in representative runs.",
+      "command": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'What should I run next?' --format markdown",
+      "chatPrompt": "What should I run next?",
+      "toolsetId": "token-usage-observer"
+    }
+  },
+  "improvementBrief": {
+    "title": "Improve audit-prompt-caching",
+    "target": {
+      "kind": "skill",
+      "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+      "entryPath": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+      "name": "audit-prompt-caching",
+      "relativePath": "audit-prompt-caching"
+    },
+    "summary": "Raise the evaluation from grade D (68/100) with a focus on the highest-signal structural and budget issues first.",
+    "goals": [
+      "Reduce repeated instruction text and move detail into deferred supporting files.",
+      "Split complex functions into smaller helpers or guard clauses.",
+      "Break large functions into smaller helpers with clear names.",
+      "Add `test_*.py` or `tests/` coverage for the main Python logic."
+    ],
+    "measurementGoals": [
+      "token-usage-observer",
+      "task-outcome-scorecard",
+      "latency-efficiency"
+    ],
+    "requiredFixes": [
+      {
+        "id": "deferred_cost_tokens-budget-high",
+        "message": "deferred_cost_tokens is excessive relative to the current Codex baseline.",
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ]
+      }
+    ],
+    "recommendedFixes": [
+      {
+        "id": "invoke_cost_tokens-budget-high",
+        "message": "invoke_cost_tokens is heavy relative to the current Codex baseline.",
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ]
+      },
+      {
+        "id": "py-complexity-high",
+        "message": "At least one Python function has high cyclomatic complexity.",
+        "remediation": [
+          "Split complex functions into smaller helpers or guard clauses."
+        ]
+      },
+      {
+        "id": "py-function-length-high",
+        "message": "At least one Python function is long enough to hurt readability.",
+        "remediation": [
+          "Break large functions into smaller helpers with clear names."
+        ]
+      },
+      {
+        "id": "py-tests-missing",
+        "message": "Python source files were found without matching test files.",
+        "remediation": [
+          "Add `test_*.py` or `tests/` coverage for the main Python logic."
+        ]
+      }
+    ],
+    "suggestedPrompt": "Use the skill-creator guidance to improve audit-prompt-caching. Keep the structure compact and move bulky details into references or scripts. Define success measures with these toolsets: token-usage-observer, task-outcome-scorecard, latency-efficiency. Address deferred_cost_tokens-budget-high: deferred_cost_tokens is excessive relative to the current Codex baseline. Address invoke_cost_tokens-budget-high: invoke_cost_tokens is heavy relative to the current Codex baseline. Address py-complexity-high: At least one Python function has high cyclomatic complexity. Address py-function-length-high: At least one Python function is long enough to hurt readability. Address py-tests-missing: Python source files were found without matching test files."
+  },
+  "nextAction": {
+    "label": "Measure real token usage next",
+    "why": "The static budget looks heavy, so live usage is the fastest way to confirm whether the cost is acceptable.",
+    "command": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Measure the real token usage of this skill.' --format markdown",
+    "chatPrompt": "Measure the real token usage of this skill."
+  },
+  "workflowGuide": {
+    "kind": "workflow-guide",
+    "createdAt": "2026-08-12T23:21:46.497Z",
+    "target": {
+      "kind": "skill",
+      "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+      "entryPath": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+      "name": "audit-prompt-caching",
+      "relativePath": "audit-prompt-caching"
+    },
+    "requestedGoal": "evaluate",
+    "requestedChatPrompt": null,
+    "requestRouting": null,
+    "recommendedWorkflowId": "evaluate",
+    "recommendedWorkflow": {
+      "id": "evaluate",
+      "label": "Evaluate Skill",
+      "chatPrompt": "Evaluate this skill.",
+      "summary": "Start here when you want the overall report for a skill, including structure, budgets, and code checks.",
+      "firstCommand": "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+      "commands": [
+        "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown"
+      ],
+      "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Evaluate this skill.' --format markdown"
+    },
+    "workflowStatus": {
+      "hasBenchmarkConfig": false,
+      "hasUsageLog": false
+    },
+    "beginnerSummary": "Start with a natural chat request, then let plugin-eval show the exact local command sequence behind it.",
+    "startHere": {
+      "chatPrompt": "Evaluate this skill.",
+      "label": "Evaluate Skill",
+      "summary": "Start here when you want the overall report for a skill, including structure, budgets, and code checks.",
+      "routingExplanation": "Plugin Eval recommended Evaluate Skill from the current local state for this skill.",
+      "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Evaluate this skill.' --format markdown",
+      "firstCommand": "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+      "commands": [
+        "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown"
+      ]
+    },
+    "entrypoints": [
+      {
+        "id": "analysis",
+        "label": "Full Skill Analysis",
+        "chatPrompt": "Give me a full analysis of this skill, including benchmark setup.",
+        "summary": "Use this when you want the full report and starter benchmark setup for this skill in one guided path.",
+        "firstCommand": "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+        "commands": [
+          "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+          "plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+          "plugin-eval benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --config ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/.plugin-eval/benchmark.json"
+        ],
+        "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Give me a full analysis of this skill, including benchmark setup.' --format markdown"
+      },
+      {
+        "id": "evaluate",
+        "label": "Evaluate Skill",
+        "chatPrompt": "Evaluate this skill.",
+        "summary": "Start here when you want the overall report for a skill, including structure, budgets, and code checks.",
+        "firstCommand": "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+        "commands": [
+          "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown"
+        ],
+        "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Evaluate this skill.' --format markdown"
+      },
+      {
+        "id": "budget",
+        "label": "Explain Token Budget",
+        "chatPrompt": "Explain the token budget for this skill.",
+        "summary": "Use this when the main question is why the skill feels expensive before you collect any live measurements.",
+        "firstCommand": "plugin-eval explain-budget ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+        "commands": [
+          "plugin-eval explain-budget ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown"
+        ],
+        "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Explain the token budget for this skill.' --format markdown"
+      },
+      {
+        "id": "measure",
+        "label": "Measure Real Token Usage",
+        "chatPrompt": "Measure the real token usage of this skill.",
+        "summary": "Use this when you want real token usage instead of only the static estimate.",
+        "firstCommand": "plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+        "commands": [
+          "plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+          "plugin-eval benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --config ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/.plugin-eval/benchmark.json",
+          "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --observed-usage ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/.plugin-eval/benchmark-usage.jsonl --format markdown"
+        ],
+        "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Measure the real token usage of this skill.' --format markdown"
+      },
+      {
+        "id": "benchmark",
+        "label": "Benchmark With Starter Scenarios",
+        "chatPrompt": "Help me benchmark this skill.",
+        "summary": "Use this when you want starter scenarios and a repeatable real-Codex benchmark run for this skill.",
+        "firstCommand": "plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+        "commands": [
+          "plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching"
+        ],
+        "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Help me benchmark this skill.' --format markdown"
+      },
+      {
+        "id": "next",
+        "label": "Start Here",
+        "chatPrompt": "What should I run next?",
+        "summary": "If you are new to plugin-eval, start with the overall evaluation report for this skill.",
+        "firstCommand": "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+        "commands": [
+          "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown"
+        ],
+        "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'What should I run next?' --format markdown"
+      }
+    ],
+    "nextSteps": [
+      "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown"
+    ],
+    "nextAction": {
+      "label": "Evaluate Skill",
+      "why": "Plugin Eval recommended Evaluate Skill from the current local state for this skill.",
+      "command": "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+      "chatPrompt": "Evaluate this skill."
+    }
+  }
+}

--- a/docs/superpowers/specs/2026-08-13-plugin-eval-after.md
+++ b/docs/superpowers/specs/2026-08-13-plugin-eval-after.md
@@ -1,0 +1,140 @@
+# Plugin Eval Report: audit-prompt-caching
+
+## At a Glance
+- Score: 68/100
+- Grade: D
+- Risk: high
+- Checks: 1 fail, 4 warn, 2 info
+- Active budget: 5985 tokens (heavy)
+- Observed usage: not supplied
+
+## Why It Matters
+- 1 failing error check are driving the highest-confidence problems.
+- 4 warning signals still need cleanup before this feels polished.
+- budget is the largest source of score loss at -18.5 points.
+- Active budget pressure is high enough that token cost may dominate the user experience.
+- No observed usage is attached yet, so budget conclusions are still based on static estimates.
+
+## Fix First
+- [fail/error] deferred_cost_tokens is excessive relative to the current Codex baseline. Why: Budget pressure matters because always-loaded or frequently-loaded text can make the workflow feel expensive fast. Fix: Reduce repeated instruction text and move detail into deferred supporting files.
+- [warn/warning] invoke_cost_tokens is heavy relative to the current Codex baseline. Why: Budget pressure matters because always-loaded or frequently-loaded text can make the workflow feel expensive fast. Fix: Reduce repeated instruction text and move detail into deferred supporting files.
+- [warn/warning] Python source files were found without matching test files. Why: Best-practice gaps usually do not break the workflow immediately, but they make the skill harder to understand and improve. Fix: Add `test_*.py` or `tests/` coverage for the main Python logic.
+
+## Recommended Next Step
+- Measure real token usage next
+- Why: The static budget looks heavy, so live usage is the fastest way to confirm whether the cost is acceptable.
+- Chat request: "Measure the real token usage of this skill."
+- Local command: `plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Measure the real token usage of this skill.' --format markdown`
+
+## Details
+<details>
+<summary>Watch next</summary>
+
+- [warn/warning] At least one Python function has high cyclomatic complexity. Why: Complexity findings matter because they increase review cost and make generated or helper code harder to change safely. Fix: Split complex functions into smaller helpers or guard clauses.
+- [warn/warning] At least one Python function is long enough to hurt readability. Why: Readability issues slow engineers down during review, debugging, and follow-up edits. Fix: Break large functions into smaller helpers with clear names.
+</details>
+<details>
+<summary>Improvement brief</summary>
+
+- Raise the evaluation from grade D (68/100) with a focus on the highest-signal structural and budget issues first.
+- Goal: Reduce repeated instruction text and move detail into deferred supporting files.
+- Goal: Split complex functions into smaller helpers or guard clauses.
+- Goal: Break large functions into smaller helpers with clear names.
+- Goal: Add `test_*.py` or `tests/` coverage for the main Python logic.
+- Measure: token-usage-observer
+- Measure: task-outcome-scorecard
+- Measure: latency-efficiency
+- Suggested prompt: Use the skill-creator guidance to improve audit-prompt-caching. Keep the structure compact and move bulky details into references or scripts. Define success measures with these toolsets: token-usage-observer, task-outcome-scorecard, latency-efficiency. Address deferred_cost_tokens-budget-high: deferred_cost_tokens is excessive relative to the current Codex baseline. Address invoke_cost_tokens-budget-high: invoke_cost_tokens is heavy relative to the current Codex baseline. Address py-complexity-high: At least one Python function has high cyclomatic complexity. Address py-function-length-high: At least one Python function is long enough to hurt readability. Address py-tests-missing: Python source files were found without matching test files.
+</details>
+<details>
+<summary>Budgets and observed usage</summary>
+
+- trigger_cost_tokens: 135 (moderate)
+- invoke_cost_tokens: 5850 (heavy)
+- deferred_cost_tokens: 41238 (excessive)
+- total_tokens: 47223 (excessive)
+
+- No observed usage supplied.
+</details>
+<details>
+<summary>Measurement plan</summary>
+
+Combine cost, outcome, and trust signals so you can tell whether the skill or plugin is genuinely helping instead of only looking well-structured on paper.
+
+- Token Usage Observer [high] Measure how many tokens the skill or plugin actually burns in representative runs. Signals: observed_usage_sample_count, observed_input_tokens_avg, observed_total_tokens_avg, estimate_vs_observed_input_ratio. Evidence: Responses API usage logs, Codex-like session exports, JSONL traces captured from local benchmarking harnesses.
+- Task Outcome Scorecard [high] Measure whether the skill helps users finish the intended job with fewer retries and less cleanup. Signals: task_success_rate, first_pass_success_rate, retry_rate, human_override_rate. Evidence: Task run logs, Structured user acceptance checklist, Before/after comparison runs on the same prompts.
+- Tool Call Audit [medium] Check whether the agent uses the right tools, arguments, and sequencing when the skill is active. Signals: tool_call_success_rate, invalid_tool_argument_rate, recoverable_tool_failure_rate. Evidence: Tool invocation traces, Recorded sessions, Golden-path scenario replays.
+- Latency And Efficiency [high] Track whether the skill speeds users up enough to justify its cost. Signals: p50_time_to_first_acceptable_answer_seconds, p95_time_to_task_completion_seconds, tokens_per_successful_run. Evidence: Benchmark harness timings, Manual stopwatch runs on canonical tasks, Responses API timestamps combined with usage logs.
+- Human Rubric Review [medium] Capture clarity, trust, and usefulness signals that automated checks will miss. Signals: clarity_score_avg, confidence_score_avg, follow_up_question_rate. Evidence: Reviewer scorecards, Team rubric sheets, Annotated transcripts.
+- Regression Suite [medium] Protect the repository behavior that the skill is supposed to improve. Signals: test_pass_rate, lint_pass_rate, regression_escape_count. Evidence: Unit and integration test runs, Coverage deltas, Snapshot or golden-file checks.
+</details>
+<details>
+<summary>Use From Codex Chat</summary>
+
+Start with a natural chat request, then let plugin-eval show the exact local command sequence behind it.
+
+Start with this chat request: "Evaluate this skill."
+Why this path: Plugin Eval recommended Evaluate Skill from the current local state for this skill.
+Quick local entrypoint: plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Evaluate this skill.' --format markdown
+Plugin Eval will run first: plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+
+Other chat requests you can use:
+- Full Skill Analysis: say "Give me a full analysis of this skill, including benchmark setup." -> plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+- Evaluate Skill: say "Evaluate this skill." -> plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+- Explain Token Budget: say "Explain the token budget for this skill." -> plugin-eval explain-budget ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+- Measure Real Token Usage: say "Measure the real token usage of this skill." -> plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching
+- Benchmark With Starter Scenarios: say "Help me benchmark this skill." -> plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching
+- Start Here: say "What should I run next?" -> plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+</details>
+<details>
+<summary>Checks</summary>
+
+- [WARN] invoke_cost_tokens-budget-high: invoke_cost_tokens is heavy relative to the current Codex baseline. Evidence: Value: 5850 tokens Baseline samples: skills=12, plugins=176 Remediation: Reduce repeated instruction text and move detail into deferred supporting files.
+- [FAIL] deferred_cost_tokens-budget-high: deferred_cost_tokens is excessive relative to the current Codex baseline. Evidence: Value: 41238 tokens Baseline samples: skills=12, plugins=176 Remediation: Reduce repeated instruction text and move detail into deferred supporting files.
+- [WARN] py-complexity-high: At least one Python function has high cyclomatic complexity. Evidence: Max complexity: 124 Remediation: Split complex functions into smaller helpers or guard clauses.
+- [WARN] py-function-length-high: At least one Python function is long enough to hurt readability. Evidence: Max function length: 118 lines Remediation: Break large functions into smaller helpers with clear names.
+- [WARN] py-tests-missing: Python source files were found without matching test files. Evidence: Source files: 8 Remediation: Add `test_*.py` or `tests/` coverage for the main Python logic.
+- [INFO] coverage-artifacts-unavailable: No coverage artifacts were found for this target. Evidence: audit-prompt-caching Remediation: Generate `lcov.info`, `coverage.xml`, or an Istanbul coverage JSON file if you want coverage scoring.
+</details>
+<details>
+<summary>Metrics</summary>
+
+- skill_line_count: 307 lines (good)
+- description_length_chars: 517 chars (moderate)
+- relative_link_count: 0 links (good)
+- code_fence_count: 1 blocks (good)
+- support_file_count: 34 files (good)
+- trigger_cost_tokens: 135 tokens (moderate)
+- invoke_cost_tokens: 5850 tokens (heavy)
+- deferred_cost_tokens: 41238 tokens (excessive)
+- py_file_count: 8 files (good)
+- py_function_count: 111 functions (good)
+- py_max_cyclomatic_complexity: 124 score (heavy)
+- py_average_function_length: 14.77 lines (good)
+- py_max_nesting_depth: 8 levels (heavy)
+- py_comment_ratio: 0.005 ratio (moderate)
+- py_test_file_count: 0 files (moderate)
+- coverage_artifact_count: 0 files (info)
+</details>
+<details>
+<summary>Score details</summary>
+
+- Starting score: 100
+- Total deductions: -32.25
+- Final score: 68
+- Risk: Contains 1 failing error check (deferred_cost_tokens-budget-high).
+- Risk: Overall score is below 70, which the evaluator treats as high risk.
+
+- -14 points: deferred_cost_tokens-budget-high [fail/error] deferred_cost_tokens is excessive relative to the current Codex baseline.
+- -4.5 points: invoke_cost_tokens-budget-high [warn/warning] invoke_cost_tokens is heavy relative to the current Codex baseline.
+- -4.5 points: py-complexity-high [warn/warning] At least one Python function has high cyclomatic complexity.
+- -4.5 points: py-function-length-high [warn/warning] At least one Python function is long enough to hurt readability.
+- -4.5 points: py-tests-missing [warn/warning] Python source files were found without matching test files.
+- -0.25 points: coverage-artifacts-unavailable [info/info] No coverage artifacts were found for this target.
+
+- budget: -18.5 points across 2 checks
+- best-practice: -4.5 points across 1 check
+- complexity: -4.5 points across 1 check
+- readability: -4.5 points across 1 check
+- coverage: -0.25 points across 1 check
+</details>

--- a/docs/superpowers/specs/2026-08-13-plugin-eval-before.json
+++ b/docs/superpowers/specs/2026-08-13-plugin-eval-before.json
@@ -1,0 +1,1768 @@
+{
+  "schemaVersion": 1,
+  "tool": {
+    "name": "plugin-eval",
+    "version": "0.1.0"
+  },
+  "createdAt": "2026-08-12T22:07:30.670Z",
+  "target": {
+    "kind": "skill",
+    "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+    "entryPath": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+    "name": "audit-prompt-caching",
+    "relativePath": "audit-prompt-caching"
+  },
+  "summary": {
+    "score": 54,
+    "grade": "F",
+    "riskLevel": "high",
+    "riskReasons": [
+      "Contains 2 failing error checks (deferred_cost_tokens-budget-high, trigger_cost_tokens-budget-high).",
+      "Overall score is below 70, which the evaluator treats as high risk."
+    ],
+    "scoreBreakdown": {
+      "startingScore": 100,
+      "totalDeductions": 46.25,
+      "finalScore": 54,
+      "gradeThresholds": {
+        "A": 93,
+        "B": 85,
+        "C": 70,
+        "D": 55
+      }
+    },
+    "checkCounts": {
+      "total": 7,
+      "pass": 0,
+      "warn": 4,
+      "fail": 2,
+      "info": 2,
+      "error": 2,
+      "warning": 4
+    },
+    "deductions": [
+      {
+        "id": "deferred_cost_tokens-budget-high",
+        "category": "budget",
+        "severity": "error",
+        "status": "fail",
+        "message": "deferred_cost_tokens is excessive relative to the current Codex baseline.",
+        "penalty": 14,
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ],
+        "source": "core"
+      },
+      {
+        "id": "trigger_cost_tokens-budget-high",
+        "category": "budget",
+        "severity": "error",
+        "status": "fail",
+        "message": "trigger_cost_tokens is excessive relative to the current Codex baseline.",
+        "penalty": 14,
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ],
+        "source": "core"
+      },
+      {
+        "id": "invoke_cost_tokens-budget-high",
+        "category": "budget",
+        "severity": "warning",
+        "status": "warn",
+        "message": "invoke_cost_tokens is heavy relative to the current Codex baseline.",
+        "penalty": 4.5,
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ],
+        "source": "core"
+      },
+      {
+        "id": "py-complexity-high",
+        "category": "complexity",
+        "severity": "warning",
+        "status": "warn",
+        "message": "At least one Python function has high cyclomatic complexity.",
+        "penalty": 4.5,
+        "remediation": [
+          "Split complex functions into smaller helpers or guard clauses."
+        ],
+        "source": "core"
+      },
+      {
+        "id": "py-function-length-high",
+        "category": "readability",
+        "severity": "warning",
+        "status": "warn",
+        "message": "At least one Python function is long enough to hurt readability.",
+        "penalty": 4.5,
+        "remediation": [
+          "Break large functions into smaller helpers with clear names."
+        ],
+        "source": "core"
+      },
+      {
+        "id": "py-tests-missing",
+        "category": "best-practice",
+        "severity": "warning",
+        "status": "warn",
+        "message": "Python source files were found without matching test files.",
+        "penalty": 4.5,
+        "remediation": [
+          "Add `test_*.py` or `tests/` coverage for the main Python logic."
+        ],
+        "source": "core"
+      },
+      {
+        "id": "coverage-artifacts-unavailable",
+        "category": "coverage",
+        "severity": "info",
+        "status": "info",
+        "message": "No coverage artifacts were found for this target.",
+        "penalty": 0.25,
+        "remediation": [
+          "Generate `lcov.info`, `coverage.xml`, or an Istanbul coverage JSON file if you want coverage scoring."
+        ],
+        "source": "core"
+      }
+    ],
+    "categoryDeductions": [
+      {
+        "category": "budget",
+        "totalPenalty": 32.5,
+        "checks": 3
+      },
+      {
+        "category": "best-practice",
+        "totalPenalty": 4.5,
+        "checks": 1
+      },
+      {
+        "category": "complexity",
+        "totalPenalty": 4.5,
+        "checks": 1
+      },
+      {
+        "category": "readability",
+        "totalPenalty": 4.5,
+        "checks": 1
+      },
+      {
+        "category": "coverage",
+        "totalPenalty": 0.25,
+        "checks": 1
+      }
+    ],
+    "topRecommendations": [
+      "Reduce repeated instruction text and move detail into deferred supporting files.",
+      "Split complex functions into smaller helpers or guard clauses.",
+      "Break large functions into smaller helpers with clear names."
+    ],
+    "whyBullets": [
+      "2 failing error checks are driving the highest-confidence problems.",
+      "4 warning signals still need cleanup before this feels polished.",
+      "budget is the largest source of score loss at -32.5 points.",
+      "Active budget pressure is high enough that token cost may dominate the user experience.",
+      "No observed usage is attached yet, so budget conclusions are still based on static estimates."
+    ],
+    "fixFirst": [
+      {
+        "id": "deferred_cost_tokens-budget-high",
+        "category": "budget",
+        "severity": "error",
+        "status": "fail",
+        "message": "deferred_cost_tokens is excessive relative to the current Codex baseline.",
+        "why": "Budget pressure matters because always-loaded or frequently-loaded text can make the workflow feel expensive fast.",
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ],
+        "penalty": 14,
+        "source": "core"
+      },
+      {
+        "id": "trigger_cost_tokens-budget-high",
+        "category": "budget",
+        "severity": "error",
+        "status": "fail",
+        "message": "trigger_cost_tokens is excessive relative to the current Codex baseline.",
+        "why": "Budget pressure matters because always-loaded or frequently-loaded text can make the workflow feel expensive fast.",
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ],
+        "penalty": 14,
+        "source": "core"
+      },
+      {
+        "id": "invoke_cost_tokens-budget-high",
+        "category": "budget",
+        "severity": "warning",
+        "status": "warn",
+        "message": "invoke_cost_tokens is heavy relative to the current Codex baseline.",
+        "why": "Budget pressure matters because always-loaded or frequently-loaded text can make the workflow feel expensive fast.",
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ],
+        "penalty": 4.5,
+        "source": "core"
+      }
+    ],
+    "watchNext": [
+      {
+        "id": "py-tests-missing",
+        "category": "best-practice",
+        "severity": "warning",
+        "status": "warn",
+        "message": "Python source files were found without matching test files.",
+        "why": "Best-practice gaps usually do not break the workflow immediately, but they make the skill harder to understand and improve.",
+        "remediation": [
+          "Add `test_*.py` or `tests/` coverage for the main Python logic."
+        ],
+        "penalty": 4.5,
+        "source": "core"
+      },
+      {
+        "id": "py-complexity-high",
+        "category": "complexity",
+        "severity": "warning",
+        "status": "warn",
+        "message": "At least one Python function has high cyclomatic complexity.",
+        "why": "Complexity findings matter because they increase review cost and make generated or helper code harder to change safely.",
+        "remediation": [
+          "Split complex functions into smaller helpers or guard clauses."
+        ],
+        "penalty": 4.5,
+        "source": "core"
+      },
+      {
+        "id": "py-function-length-high",
+        "category": "readability",
+        "severity": "warning",
+        "status": "warn",
+        "message": "At least one Python function is long enough to hurt readability.",
+        "why": "Readability issues slow engineers down during review, debugging, and follow-up edits.",
+        "remediation": [
+          "Break large functions into smaller helpers with clear names."
+        ],
+        "penalty": 4.5,
+        "source": "core"
+      }
+    ]
+  },
+  "budgets": {
+    "method": "estimated-static",
+    "invocation_policy": {
+      "allow_implicit_invocation": true,
+      "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/agents/openai.yaml"
+    },
+    "trigger_cost_tokens": {
+      "value": 170,
+      "band": "excessive",
+      "thresholds": {
+        "goodMax": 96,
+        "moderateMax": 139,
+        "heavyMax": 164
+      },
+      "components": [
+        {
+          "label": "skill-name",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+          "tokens": 5,
+          "note": "Always-loaded skill identifier"
+        },
+        {
+          "label": "skill-description",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+          "tokens": 165,
+          "note": "Always-loaded trigger description"
+        }
+      ]
+    },
+    "invoke_cost_tokens": {
+      "value": 5852,
+      "band": "heavy",
+      "thresholds": {
+        "goodMax": 1380,
+        "moderateMax": 2039,
+        "heavyMax": 6905
+      },
+      "components": [
+        {
+          "label": "skill-file",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+          "tokens": 5852,
+          "note": "Loaded when the skill is invoked"
+        }
+      ]
+    },
+    "deferred_cost_tokens": {
+      "value": 37740,
+      "band": "excessive",
+      "thresholds": {
+        "goodMax": 3771,
+        "moderateMax": 17846,
+        "heavyMax": 26574
+      },
+      "components": [
+        {
+          "label": "agents/openai.yaml",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/agents/openai.yaml",
+          "tokens": 65,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "evals/evals.json",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/evals/evals.json",
+          "tokens": 1282,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "evals/trigger_eval.json",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/evals/trigger_eval.json",
+          "tokens": 774,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/agent-tools.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/agent-tools.md",
+          "tokens": 2125,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/anthropic.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/anthropic.md",
+          "tokens": 951,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/azure-openai.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/azure-openai.md",
+          "tokens": 1011,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/bedrock.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/bedrock.md",
+          "tokens": 521,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/deepseek.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/deepseek.md",
+          "tokens": 721,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/economics.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/economics.md",
+          "tokens": 407,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/gemini.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/gemini.md",
+          "tokens": 1169,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/mastra.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/mastra.md",
+          "tokens": 614,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/mechanics.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/mechanics.md",
+          "tokens": 672,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/observability.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/observability.md",
+          "tokens": 501,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/openai.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/openai.md",
+          "tokens": 1972,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/openrouter.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/openrouter.md",
+          "tokens": 820,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/operational-playbook.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/operational-playbook.md",
+          "tokens": 574,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/predeploy-checklist.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/predeploy-checklist.md",
+          "tokens": 422,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/qwen.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/qwen.md",
+          "tokens": 962,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/report-template.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/report-template.md",
+          "tokens": 348,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/rules.json",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/rules.json",
+          "tokens": 1257,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/sglang.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/sglang.md",
+          "tokens": 984,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/use-cases.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/use-cases.md",
+          "tokens": 699,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/vercel-ai-sdk.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/vercel-ai-sdk.md",
+          "tokens": 863,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/vllm.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/vllm.md",
+          "tokens": 859,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/yandexgpt.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/yandexgpt.md",
+          "tokens": 671,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "references/zai.md",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/zai.md",
+          "tokens": 671,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/analyze_usage_logs.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/analyze_usage_logs.py",
+          "tokens": 4603,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/estimate_cache_roi.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/estimate_cache_roi.py",
+          "tokens": 1495,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/extract_llm_calls.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/extract_llm_calls.py",
+          "tokens": 1143,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/layout_linter.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/layout_linter.py",
+          "tokens": 3263,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/prefix_stability_check.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/prefix_stability_check.py",
+          "tokens": 866,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/render_audit_report.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/render_audit_report.py",
+          "tokens": 2963,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/run_trigger_eval.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/run_trigger_eval.py",
+          "tokens": 603,
+          "note": "Deferred supporting file"
+        },
+        {
+          "label": "scripts/validate_skill_package.py",
+          "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/validate_skill_package.py",
+          "tokens": 889,
+          "note": "Deferred supporting file"
+        }
+      ]
+    },
+    "total_tokens": {
+      "value": 43762,
+      "band": "excessive"
+    }
+  },
+  "observedUsage": null,
+  "checks": [
+    {
+      "id": "trigger_cost_tokens-budget-high",
+      "category": "budget",
+      "severity": "error",
+      "status": "fail",
+      "message": "trigger_cost_tokens is excessive relative to the current Codex baseline.",
+      "evidence": [
+        "Value: 170 tokens",
+        "Baseline samples: skills=12, plugins=176"
+      ],
+      "remediation": [
+        "Reduce repeated instruction text and move detail into deferred supporting files."
+      ],
+      "source": "core"
+    },
+    {
+      "id": "invoke_cost_tokens-budget-high",
+      "category": "budget",
+      "severity": "warning",
+      "status": "warn",
+      "message": "invoke_cost_tokens is heavy relative to the current Codex baseline.",
+      "evidence": [
+        "Value: 5852 tokens",
+        "Baseline samples: skills=12, plugins=176"
+      ],
+      "remediation": [
+        "Reduce repeated instruction text and move detail into deferred supporting files."
+      ],
+      "source": "core"
+    },
+    {
+      "id": "deferred_cost_tokens-budget-high",
+      "category": "budget",
+      "severity": "error",
+      "status": "fail",
+      "message": "deferred_cost_tokens is excessive relative to the current Codex baseline.",
+      "evidence": [
+        "Value: 37740 tokens",
+        "Baseline samples: skills=12, plugins=176"
+      ],
+      "remediation": [
+        "Reduce repeated instruction text and move detail into deferred supporting files."
+      ],
+      "source": "core"
+    },
+    {
+      "id": "py-complexity-high",
+      "category": "complexity",
+      "severity": "warning",
+      "status": "warn",
+      "message": "At least one Python function has high cyclomatic complexity.",
+      "evidence": [
+        "Max complexity: 99"
+      ],
+      "remediation": [
+        "Split complex functions into smaller helpers or guard clauses."
+      ],
+      "source": "core"
+    },
+    {
+      "id": "py-function-length-high",
+      "category": "readability",
+      "severity": "warning",
+      "status": "warn",
+      "message": "At least one Python function is long enough to hurt readability.",
+      "evidence": [
+        "Max function length: 118 lines"
+      ],
+      "remediation": [
+        "Break large functions into smaller helpers with clear names."
+      ],
+      "source": "core"
+    },
+    {
+      "id": "py-tests-missing",
+      "category": "best-practice",
+      "severity": "warning",
+      "status": "warn",
+      "message": "Python source files were found without matching test files.",
+      "evidence": [
+        "Source files: 8"
+      ],
+      "remediation": [
+        "Add `test_*.py` or `tests/` coverage for the main Python logic."
+      ],
+      "source": "core"
+    },
+    {
+      "id": "coverage-artifacts-unavailable",
+      "category": "coverage",
+      "severity": "info",
+      "status": "info",
+      "message": "No coverage artifacts were found for this target.",
+      "evidence": [
+        "audit-prompt-caching"
+      ],
+      "remediation": [
+        "Generate `lcov.info`, `coverage.xml`, or an Istanbul coverage JSON file if you want coverage scoring."
+      ],
+      "source": "core"
+    }
+  ],
+  "metrics": [
+    {
+      "id": "skill_line_count",
+      "category": "budget",
+      "value": 310,
+      "unit": "lines",
+      "band": "good",
+      "source": "core",
+      "targetPath": "audit-prompt-caching"
+    },
+    {
+      "id": "description_length_chars",
+      "category": "budget",
+      "value": 657,
+      "unit": "chars",
+      "band": "moderate",
+      "source": "core",
+      "targetPath": "audit-prompt-caching"
+    },
+    {
+      "id": "relative_link_count",
+      "category": "documentation",
+      "value": 0,
+      "unit": "links",
+      "band": "good",
+      "source": "core",
+      "targetPath": "audit-prompt-caching"
+    },
+    {
+      "id": "code_fence_count",
+      "category": "readability",
+      "value": 3,
+      "unit": "blocks",
+      "band": "good",
+      "source": "core",
+      "targetPath": "audit-prompt-caching"
+    },
+    {
+      "id": "support_file_count",
+      "category": "documentation",
+      "value": 34,
+      "unit": "files",
+      "band": "good",
+      "source": "core",
+      "targetPath": "audit-prompt-caching"
+    },
+    {
+      "id": "trigger_cost_tokens",
+      "category": "budget",
+      "value": 170,
+      "unit": "tokens",
+      "band": "excessive",
+      "source": "core"
+    },
+    {
+      "id": "invoke_cost_tokens",
+      "category": "budget",
+      "value": 5852,
+      "unit": "tokens",
+      "band": "heavy",
+      "source": "core"
+    },
+    {
+      "id": "deferred_cost_tokens",
+      "category": "budget",
+      "value": 37740,
+      "unit": "tokens",
+      "band": "excessive",
+      "source": "core"
+    },
+    {
+      "id": "py_file_count",
+      "category": "code-quality",
+      "value": 8,
+      "unit": "files",
+      "band": "good",
+      "source": "core"
+    },
+    {
+      "id": "py_function_count",
+      "category": "code-quality",
+      "value": 94,
+      "unit": "functions",
+      "band": "good",
+      "source": "core"
+    },
+    {
+      "id": "py_max_cyclomatic_complexity",
+      "category": "complexity",
+      "value": 99,
+      "unit": "score",
+      "band": "heavy",
+      "source": "core"
+    },
+    {
+      "id": "py_average_function_length",
+      "category": "readability",
+      "value": 15.56,
+      "unit": "lines",
+      "band": "good",
+      "source": "core"
+    },
+    {
+      "id": "py_max_nesting_depth",
+      "category": "complexity",
+      "value": 8,
+      "unit": "levels",
+      "band": "heavy",
+      "source": "core"
+    },
+    {
+      "id": "py_comment_ratio",
+      "category": "readability",
+      "value": 0.006,
+      "unit": "ratio",
+      "band": "moderate",
+      "source": "core"
+    },
+    {
+      "id": "py_test_file_count",
+      "category": "best-practice",
+      "value": 0,
+      "unit": "files",
+      "band": "moderate",
+      "source": "core"
+    },
+    {
+      "id": "coverage_artifact_count",
+      "category": "coverage",
+      "value": 0,
+      "unit": "files",
+      "band": "info",
+      "source": "core"
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "skill-link-inventory",
+      "type": "inventory",
+      "label": "Skill relative links",
+      "description": "Relative links found in SKILL.md.",
+      "source": "core",
+      "data": {
+        "links": []
+      }
+    },
+    {
+      "id": "budget-breakdown",
+      "type": "budget",
+      "label": "Budget breakdown",
+      "description": "Trigger, invoke, and deferred token budget analysis.",
+      "source": "core",
+      "data": {
+        "budgets": {
+          "method": "estimated-static",
+          "invocation_policy": {
+            "allow_implicit_invocation": true,
+            "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/agents/openai.yaml"
+          },
+          "trigger_cost_tokens": {
+            "value": 170,
+            "band": "excessive",
+            "thresholds": {
+              "goodMax": 96,
+              "moderateMax": 139,
+              "heavyMax": 164
+            },
+            "components": [
+              {
+                "label": "skill-name",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+                "tokens": 5,
+                "note": "Always-loaded skill identifier"
+              },
+              {
+                "label": "skill-description",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+                "tokens": 165,
+                "note": "Always-loaded trigger description"
+              }
+            ]
+          },
+          "invoke_cost_tokens": {
+            "value": 5852,
+            "band": "heavy",
+            "thresholds": {
+              "goodMax": 1380,
+              "moderateMax": 2039,
+              "heavyMax": 6905
+            },
+            "components": [
+              {
+                "label": "skill-file",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+                "tokens": 5852,
+                "note": "Loaded when the skill is invoked"
+              }
+            ]
+          },
+          "deferred_cost_tokens": {
+            "value": 37740,
+            "band": "excessive",
+            "thresholds": {
+              "goodMax": 3771,
+              "moderateMax": 17846,
+              "heavyMax": 26574
+            },
+            "components": [
+              {
+                "label": "agents/openai.yaml",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/agents/openai.yaml",
+                "tokens": 65,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "evals/evals.json",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/evals/evals.json",
+                "tokens": 1282,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "evals/trigger_eval.json",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/evals/trigger_eval.json",
+                "tokens": 774,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/agent-tools.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/agent-tools.md",
+                "tokens": 2125,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/anthropic.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/anthropic.md",
+                "tokens": 951,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/azure-openai.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/azure-openai.md",
+                "tokens": 1011,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/bedrock.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/bedrock.md",
+                "tokens": 521,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/deepseek.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/deepseek.md",
+                "tokens": 721,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/economics.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/economics.md",
+                "tokens": 407,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/gemini.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/gemini.md",
+                "tokens": 1169,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/mastra.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/mastra.md",
+                "tokens": 614,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/mechanics.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/mechanics.md",
+                "tokens": 672,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/observability.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/observability.md",
+                "tokens": 501,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/openai.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/openai.md",
+                "tokens": 1972,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/openrouter.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/openrouter.md",
+                "tokens": 820,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/operational-playbook.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/operational-playbook.md",
+                "tokens": 574,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/predeploy-checklist.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/predeploy-checklist.md",
+                "tokens": 422,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/qwen.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/qwen.md",
+                "tokens": 962,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/report-template.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/report-template.md",
+                "tokens": 348,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/rules.json",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/rules.json",
+                "tokens": 1257,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/sglang.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/sglang.md",
+                "tokens": 984,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/use-cases.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/use-cases.md",
+                "tokens": 699,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/vercel-ai-sdk.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/vercel-ai-sdk.md",
+                "tokens": 863,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/vllm.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/vllm.md",
+                "tokens": 859,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/yandexgpt.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/yandexgpt.md",
+                "tokens": 671,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "references/zai.md",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/references/zai.md",
+                "tokens": 671,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/analyze_usage_logs.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/analyze_usage_logs.py",
+                "tokens": 4603,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/estimate_cache_roi.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/estimate_cache_roi.py",
+                "tokens": 1495,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/extract_llm_calls.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/extract_llm_calls.py",
+                "tokens": 1143,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/layout_linter.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/layout_linter.py",
+                "tokens": 3263,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/prefix_stability_check.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/prefix_stability_check.py",
+                "tokens": 866,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/render_audit_report.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/render_audit_report.py",
+                "tokens": 2963,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/run_trigger_eval.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/run_trigger_eval.py",
+                "tokens": 603,
+                "note": "Deferred supporting file"
+              },
+              {
+                "label": "scripts/validate_skill_package.py",
+                "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/scripts/validate_skill_package.py",
+                "tokens": 889,
+                "note": "Deferred supporting file"
+              }
+            ]
+          },
+          "total_tokens": {
+            "value": 43762,
+            "band": "excessive"
+          }
+        },
+        "baselineEvidence": {
+          "skillSamples": 12,
+          "pluginSamples": 176,
+          "sourceRoots": [
+            "../../../../../.codex/skills",
+            "../../../../../.codex/plugins/cache/openai-curated",
+            "../../../../../.codex/.tmp/plugins/plugins"
+          ]
+        }
+      }
+    },
+    {
+      "id": "py-per-file-analysis",
+      "type": "analysis",
+      "label": "Python per-file analysis",
+      "description": "Heuristic Python quality and complexity breakdown by file.",
+      "source": "core",
+      "data": {
+        "files": [
+          {
+            "path": "scripts/analyze_usage_logs.py",
+            "functionCount": 44,
+            "complexity": 96,
+            "maxFunctionLength": 53,
+            "maxNesting": 7,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/estimate_cache_roi.py",
+            "functionCount": 6,
+            "complexity": 23,
+            "maxFunctionLength": 74,
+            "maxNesting": 4,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/extract_llm_calls.py",
+            "functionCount": 4,
+            "complexity": 18,
+            "maxFunctionLength": 33,
+            "maxNesting": 8,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/layout_linter.py",
+            "functionCount": 18,
+            "complexity": 99,
+            "maxFunctionLength": 118,
+            "maxNesting": 5,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/prefix_stability_check.py",
+            "functionCount": 5,
+            "complexity": 18,
+            "maxFunctionLength": 50,
+            "maxNesting": 3,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/render_audit_report.py",
+            "functionCount": 9,
+            "complexity": 48,
+            "maxFunctionLength": 100,
+            "maxNesting": 7,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/run_trigger_eval.py",
+            "functionCount": 3,
+            "complexity": 22,
+            "maxFunctionLength": 28,
+            "maxNesting": 3,
+            "longLines": 0
+          },
+          {
+            "path": "scripts/validate_skill_package.py",
+            "functionCount": 5,
+            "complexity": 27,
+            "maxFunctionLength": 51,
+            "maxNesting": 3,
+            "longLines": 0
+          }
+        ]
+      }
+    },
+    {
+      "id": "measurement-plan",
+      "type": "measurement-plan",
+      "label": "Measurement plan",
+      "description": "Recommended toolsets for measuring the real-world effect of this skill or plugin.",
+      "source": "core",
+      "data": {
+        "recommendedToolsets": [
+          "token-usage-observer",
+          "task-outcome-scorecard",
+          "latency-efficiency"
+        ],
+        "toolsets": [
+          {
+            "id": "token-usage-observer",
+            "label": "Token Usage Observer",
+            "priority": "high",
+            "goal": "Measure how many tokens the skill or plugin actually burns in representative runs.",
+            "why": "Static estimates are useful guardrails, but observed usage is what tells you whether a real workflow is affordable and whether caching or reasoning changes the picture.",
+            "signals": [
+              "observed_usage_sample_count",
+              "observed_input_tokens_avg",
+              "observed_total_tokens_avg",
+              "estimate_vs_observed_input_ratio"
+            ],
+            "evidenceSources": [
+              "Responses API usage logs",
+              "Codex-like session exports",
+              "JSONL traces captured from local benchmarking harnesses"
+            ],
+            "starterPack": {
+              "manifestName": "token-usage-pack",
+              "focus": "Validate sample size, cold-start versus warm-cache behavior, and estimate drift over time."
+            }
+          },
+          {
+            "id": "task-outcome-scorecard",
+            "label": "Task Outcome Scorecard",
+            "priority": "high",
+            "goal": "Measure whether the skill helps users finish the intended job with fewer retries and less cleanup.",
+            "why": "A low-token skill is still a miss if it fails the task, and a verbose skill may be worth it if it consistently improves first-pass success.",
+            "signals": [
+              "task_success_rate",
+              "first_pass_success_rate",
+              "retry_rate",
+              "human_override_rate"
+            ],
+            "evidenceSources": [
+              "Task run logs",
+              "Structured user acceptance checklist",
+              "Before/after comparison runs on the same prompts"
+            ],
+            "starterPack": {
+              "manifestName": "task-outcomes-pack",
+              "focus": "Score success, retries, and manual intervention across a fixed prompt set."
+            }
+          },
+          {
+            "id": "tool-call-audit",
+            "label": "Tool Call Audit",
+            "priority": "medium",
+            "goal": "Check whether the agent uses the right tools, arguments, and sequencing when the skill is active.",
+            "why": "For Codex plugins and many higher-agency skills, tool correctness is often the real determinant of user value.",
+            "signals": [
+              "tool_call_success_rate",
+              "invalid_tool_argument_rate",
+              "recoverable_tool_failure_rate"
+            ],
+            "evidenceSources": [
+              "Tool invocation traces",
+              "Recorded sessions",
+              "Golden-path scenario replays"
+            ],
+            "starterPack": {
+              "manifestName": "tool-audit-pack",
+              "focus": "Flag wrong tool selection, malformed args, and missing follow-up calls."
+            }
+          },
+          {
+            "id": "latency-efficiency",
+            "label": "Latency And Efficiency",
+            "priority": "high",
+            "goal": "Track whether the skill speeds users up enough to justify its cost.",
+            "why": "DX improvements usually win when they reduce waiting or rework, not only when they reduce absolute token counts.",
+            "signals": [
+              "p50_time_to_first_acceptable_answer_seconds",
+              "p95_time_to_task_completion_seconds",
+              "tokens_per_successful_run"
+            ],
+            "evidenceSources": [
+              "Benchmark harness timings",
+              "Manual stopwatch runs on canonical tasks",
+              "Responses API timestamps combined with usage logs"
+            ],
+            "starterPack": {
+              "manifestName": "latency-efficiency-pack",
+              "focus": "Measure time-to-value and cost-per-success on a stable prompt suite."
+            }
+          },
+          {
+            "id": "human-rubric-review",
+            "label": "Human Rubric Review",
+            "priority": "medium",
+            "goal": "Capture clarity, trust, and usefulness signals that automated checks will miss.",
+            "why": "The best skills often reduce confusion and editing effort in ways that do not show up in static lint-like checks.",
+            "signals": [
+              "clarity_score_avg",
+              "confidence_score_avg",
+              "follow_up_question_rate"
+            ],
+            "evidenceSources": [
+              "Reviewer scorecards",
+              "Team rubric sheets",
+              "Annotated transcripts"
+            ],
+            "starterPack": {
+              "manifestName": "human-rubric-pack",
+              "focus": "Collect 1 to 5 scores for clarity, trust, and edit burden across a small evaluator panel."
+            }
+          },
+          {
+            "id": "regression-suite",
+            "label": "Regression Suite",
+            "priority": "medium",
+            "goal": "Protect the repository behavior that the skill is supposed to improve.",
+            "why": "If a skill is meant to help coding workflows, outcomes should be paired with deterministic repo checks so quality gains do not come from cutting corners.",
+            "signals": [
+              "test_pass_rate",
+              "lint_pass_rate",
+              "regression_escape_count"
+            ],
+            "evidenceSources": [
+              "Unit and integration test runs",
+              "Coverage deltas",
+              "Snapshot or golden-file checks"
+            ],
+            "starterPack": {
+              "manifestName": "regression-pack",
+              "focus": "Blend repository test outcomes with evaluation-task success metrics."
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "extensions": [],
+  "measurementPlan": {
+    "kind": "measurement-plan",
+    "createdAt": "2026-08-12T22:07:32.062Z",
+    "target": {
+      "kind": "skill",
+      "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+      "entryPath": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+      "name": "audit-prompt-caching",
+      "relativePath": "audit-prompt-caching"
+    },
+    "title": "Measurement plan for audit-prompt-caching",
+    "summary": "Combine cost, outcome, and trust signals so you can tell whether the skill or plugin is genuinely helping instead of only looking well-structured on paper.",
+    "recommendedToolsets": [
+      "token-usage-observer",
+      "task-outcome-scorecard",
+      "latency-efficiency"
+    ],
+    "toolsets": [
+      {
+        "id": "token-usage-observer",
+        "label": "Token Usage Observer",
+        "priority": "high",
+        "goal": "Measure how many tokens the skill or plugin actually burns in representative runs.",
+        "why": "Static estimates are useful guardrails, but observed usage is what tells you whether a real workflow is affordable and whether caching or reasoning changes the picture.",
+        "signals": [
+          "observed_usage_sample_count",
+          "observed_input_tokens_avg",
+          "observed_total_tokens_avg",
+          "estimate_vs_observed_input_ratio"
+        ],
+        "evidenceSources": [
+          "Responses API usage logs",
+          "Codex-like session exports",
+          "JSONL traces captured from local benchmarking harnesses"
+        ],
+        "starterPack": {
+          "manifestName": "token-usage-pack",
+          "focus": "Validate sample size, cold-start versus warm-cache behavior, and estimate drift over time."
+        }
+      },
+      {
+        "id": "task-outcome-scorecard",
+        "label": "Task Outcome Scorecard",
+        "priority": "high",
+        "goal": "Measure whether the skill helps users finish the intended job with fewer retries and less cleanup.",
+        "why": "A low-token skill is still a miss if it fails the task, and a verbose skill may be worth it if it consistently improves first-pass success.",
+        "signals": [
+          "task_success_rate",
+          "first_pass_success_rate",
+          "retry_rate",
+          "human_override_rate"
+        ],
+        "evidenceSources": [
+          "Task run logs",
+          "Structured user acceptance checklist",
+          "Before/after comparison runs on the same prompts"
+        ],
+        "starterPack": {
+          "manifestName": "task-outcomes-pack",
+          "focus": "Score success, retries, and manual intervention across a fixed prompt set."
+        }
+      },
+      {
+        "id": "tool-call-audit",
+        "label": "Tool Call Audit",
+        "priority": "medium",
+        "goal": "Check whether the agent uses the right tools, arguments, and sequencing when the skill is active.",
+        "why": "For Codex plugins and many higher-agency skills, tool correctness is often the real determinant of user value.",
+        "signals": [
+          "tool_call_success_rate",
+          "invalid_tool_argument_rate",
+          "recoverable_tool_failure_rate"
+        ],
+        "evidenceSources": [
+          "Tool invocation traces",
+          "Recorded sessions",
+          "Golden-path scenario replays"
+        ],
+        "starterPack": {
+          "manifestName": "tool-audit-pack",
+          "focus": "Flag wrong tool selection, malformed args, and missing follow-up calls."
+        }
+      },
+      {
+        "id": "latency-efficiency",
+        "label": "Latency And Efficiency",
+        "priority": "high",
+        "goal": "Track whether the skill speeds users up enough to justify its cost.",
+        "why": "DX improvements usually win when they reduce waiting or rework, not only when they reduce absolute token counts.",
+        "signals": [
+          "p50_time_to_first_acceptable_answer_seconds",
+          "p95_time_to_task_completion_seconds",
+          "tokens_per_successful_run"
+        ],
+        "evidenceSources": [
+          "Benchmark harness timings",
+          "Manual stopwatch runs on canonical tasks",
+          "Responses API timestamps combined with usage logs"
+        ],
+        "starterPack": {
+          "manifestName": "latency-efficiency-pack",
+          "focus": "Measure time-to-value and cost-per-success on a stable prompt suite."
+        }
+      },
+      {
+        "id": "human-rubric-review",
+        "label": "Human Rubric Review",
+        "priority": "medium",
+        "goal": "Capture clarity, trust, and usefulness signals that automated checks will miss.",
+        "why": "The best skills often reduce confusion and editing effort in ways that do not show up in static lint-like checks.",
+        "signals": [
+          "clarity_score_avg",
+          "confidence_score_avg",
+          "follow_up_question_rate"
+        ],
+        "evidenceSources": [
+          "Reviewer scorecards",
+          "Team rubric sheets",
+          "Annotated transcripts"
+        ],
+        "starterPack": {
+          "manifestName": "human-rubric-pack",
+          "focus": "Collect 1 to 5 scores for clarity, trust, and edit burden across a small evaluator panel."
+        }
+      },
+      {
+        "id": "regression-suite",
+        "label": "Regression Suite",
+        "priority": "medium",
+        "goal": "Protect the repository behavior that the skill is supposed to improve.",
+        "why": "If a skill is meant to help coding workflows, outcomes should be paired with deterministic repo checks so quality gains do not come from cutting corners.",
+        "signals": [
+          "test_pass_rate",
+          "lint_pass_rate",
+          "regression_escape_count"
+        ],
+        "evidenceSources": [
+          "Unit and integration test runs",
+          "Coverage deltas",
+          "Snapshot or golden-file checks"
+        ],
+        "starterPack": {
+          "manifestName": "regression-pack",
+          "focus": "Blend repository test outcomes with evaluation-task success metrics."
+        }
+      }
+    ],
+    "artifact": {
+      "id": "measurement-plan",
+      "type": "measurement-plan",
+      "label": "Measurement plan",
+      "description": "Recommended toolsets for measuring the real-world effect of this skill or plugin.",
+      "source": "core",
+      "data": {
+        "recommendedToolsets": [
+          "token-usage-observer",
+          "task-outcome-scorecard",
+          "latency-efficiency"
+        ],
+        "toolsets": [
+          {
+            "id": "token-usage-observer",
+            "label": "Token Usage Observer",
+            "priority": "high",
+            "goal": "Measure how many tokens the skill or plugin actually burns in representative runs.",
+            "why": "Static estimates are useful guardrails, but observed usage is what tells you whether a real workflow is affordable and whether caching or reasoning changes the picture.",
+            "signals": [
+              "observed_usage_sample_count",
+              "observed_input_tokens_avg",
+              "observed_total_tokens_avg",
+              "estimate_vs_observed_input_ratio"
+            ],
+            "evidenceSources": [
+              "Responses API usage logs",
+              "Codex-like session exports",
+              "JSONL traces captured from local benchmarking harnesses"
+            ],
+            "starterPack": {
+              "manifestName": "token-usage-pack",
+              "focus": "Validate sample size, cold-start versus warm-cache behavior, and estimate drift over time."
+            }
+          },
+          {
+            "id": "task-outcome-scorecard",
+            "label": "Task Outcome Scorecard",
+            "priority": "high",
+            "goal": "Measure whether the skill helps users finish the intended job with fewer retries and less cleanup.",
+            "why": "A low-token skill is still a miss if it fails the task, and a verbose skill may be worth it if it consistently improves first-pass success.",
+            "signals": [
+              "task_success_rate",
+              "first_pass_success_rate",
+              "retry_rate",
+              "human_override_rate"
+            ],
+            "evidenceSources": [
+              "Task run logs",
+              "Structured user acceptance checklist",
+              "Before/after comparison runs on the same prompts"
+            ],
+            "starterPack": {
+              "manifestName": "task-outcomes-pack",
+              "focus": "Score success, retries, and manual intervention across a fixed prompt set."
+            }
+          },
+          {
+            "id": "tool-call-audit",
+            "label": "Tool Call Audit",
+            "priority": "medium",
+            "goal": "Check whether the agent uses the right tools, arguments, and sequencing when the skill is active.",
+            "why": "For Codex plugins and many higher-agency skills, tool correctness is often the real determinant of user value.",
+            "signals": [
+              "tool_call_success_rate",
+              "invalid_tool_argument_rate",
+              "recoverable_tool_failure_rate"
+            ],
+            "evidenceSources": [
+              "Tool invocation traces",
+              "Recorded sessions",
+              "Golden-path scenario replays"
+            ],
+            "starterPack": {
+              "manifestName": "tool-audit-pack",
+              "focus": "Flag wrong tool selection, malformed args, and missing follow-up calls."
+            }
+          },
+          {
+            "id": "latency-efficiency",
+            "label": "Latency And Efficiency",
+            "priority": "high",
+            "goal": "Track whether the skill speeds users up enough to justify its cost.",
+            "why": "DX improvements usually win when they reduce waiting or rework, not only when they reduce absolute token counts.",
+            "signals": [
+              "p50_time_to_first_acceptable_answer_seconds",
+              "p95_time_to_task_completion_seconds",
+              "tokens_per_successful_run"
+            ],
+            "evidenceSources": [
+              "Benchmark harness timings",
+              "Manual stopwatch runs on canonical tasks",
+              "Responses API timestamps combined with usage logs"
+            ],
+            "starterPack": {
+              "manifestName": "latency-efficiency-pack",
+              "focus": "Measure time-to-value and cost-per-success on a stable prompt suite."
+            }
+          },
+          {
+            "id": "human-rubric-review",
+            "label": "Human Rubric Review",
+            "priority": "medium",
+            "goal": "Capture clarity, trust, and usefulness signals that automated checks will miss.",
+            "why": "The best skills often reduce confusion and editing effort in ways that do not show up in static lint-like checks.",
+            "signals": [
+              "clarity_score_avg",
+              "confidence_score_avg",
+              "follow_up_question_rate"
+            ],
+            "evidenceSources": [
+              "Reviewer scorecards",
+              "Team rubric sheets",
+              "Annotated transcripts"
+            ],
+            "starterPack": {
+              "manifestName": "human-rubric-pack",
+              "focus": "Collect 1 to 5 scores for clarity, trust, and edit burden across a small evaluator panel."
+            }
+          },
+          {
+            "id": "regression-suite",
+            "label": "Regression Suite",
+            "priority": "medium",
+            "goal": "Protect the repository behavior that the skill is supposed to improve.",
+            "why": "If a skill is meant to help coding workflows, outcomes should be paired with deterministic repo checks so quality gains do not come from cutting corners.",
+            "signals": [
+              "test_pass_rate",
+              "lint_pass_rate",
+              "regression_escape_count"
+            ],
+            "evidenceSources": [
+              "Unit and integration test runs",
+              "Coverage deltas",
+              "Snapshot or golden-file checks"
+            ],
+            "starterPack": {
+              "manifestName": "regression-pack",
+              "focus": "Blend repository test outcomes with evaluation-task success metrics."
+            }
+          }
+        ]
+      }
+    },
+    "nextAction": {
+      "label": "Start with Token Usage Observer",
+      "why": "Measure how many tokens the skill or plugin actually burns in representative runs.",
+      "command": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'What should I run next?' --format markdown",
+      "chatPrompt": "What should I run next?",
+      "toolsetId": "token-usage-observer"
+    }
+  },
+  "improvementBrief": {
+    "title": "Improve audit-prompt-caching",
+    "target": {
+      "kind": "skill",
+      "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+      "entryPath": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+      "name": "audit-prompt-caching",
+      "relativePath": "audit-prompt-caching"
+    },
+    "summary": "Raise the evaluation from grade F (54/100) with a focus on the highest-signal structural and budget issues first.",
+    "goals": [
+      "Reduce repeated instruction text and move detail into deferred supporting files.",
+      "Split complex functions into smaller helpers or guard clauses.",
+      "Break large functions into smaller helpers with clear names."
+    ],
+    "measurementGoals": [
+      "token-usage-observer",
+      "task-outcome-scorecard",
+      "latency-efficiency"
+    ],
+    "requiredFixes": [
+      {
+        "id": "trigger_cost_tokens-budget-high",
+        "message": "trigger_cost_tokens is excessive relative to the current Codex baseline.",
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ]
+      },
+      {
+        "id": "deferred_cost_tokens-budget-high",
+        "message": "deferred_cost_tokens is excessive relative to the current Codex baseline.",
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ]
+      }
+    ],
+    "recommendedFixes": [
+      {
+        "id": "invoke_cost_tokens-budget-high",
+        "message": "invoke_cost_tokens is heavy relative to the current Codex baseline.",
+        "remediation": [
+          "Reduce repeated instruction text and move detail into deferred supporting files."
+        ]
+      },
+      {
+        "id": "py-complexity-high",
+        "message": "At least one Python function has high cyclomatic complexity.",
+        "remediation": [
+          "Split complex functions into smaller helpers or guard clauses."
+        ]
+      },
+      {
+        "id": "py-function-length-high",
+        "message": "At least one Python function is long enough to hurt readability.",
+        "remediation": [
+          "Break large functions into smaller helpers with clear names."
+        ]
+      },
+      {
+        "id": "py-tests-missing",
+        "message": "Python source files were found without matching test files.",
+        "remediation": [
+          "Add `test_*.py` or `tests/` coverage for the main Python logic."
+        ]
+      }
+    ],
+    "suggestedPrompt": "Use the skill-creator guidance to improve audit-prompt-caching. Keep the structure compact and move bulky details into references or scripts. Define success measures with these toolsets: token-usage-observer, task-outcome-scorecard, latency-efficiency. Address trigger_cost_tokens-budget-high: trigger_cost_tokens is excessive relative to the current Codex baseline. Address deferred_cost_tokens-budget-high: deferred_cost_tokens is excessive relative to the current Codex baseline. Address invoke_cost_tokens-budget-high: invoke_cost_tokens is heavy relative to the current Codex baseline. Address py-complexity-high: At least one Python function has high cyclomatic complexity. Address py-function-length-high: At least one Python function is long enough to hurt readability. Address py-tests-missing: Python source files were found without matching test files."
+  },
+  "nextAction": {
+    "label": "Measure real token usage next",
+    "why": "The static budget looks heavy, so live usage is the fastest way to confirm whether the cost is acceptable.",
+    "command": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Measure the real token usage of this skill.' --format markdown",
+    "chatPrompt": "Measure the real token usage of this skill."
+  },
+  "workflowGuide": {
+    "kind": "workflow-guide",
+    "createdAt": "2026-08-12T22:07:32.063Z",
+    "target": {
+      "kind": "skill",
+      "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+      "entryPath": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+      "name": "audit-prompt-caching",
+      "relativePath": "audit-prompt-caching"
+    },
+    "requestedGoal": "evaluate",
+    "requestedChatPrompt": null,
+    "requestRouting": null,
+    "recommendedWorkflowId": "evaluate",
+    "recommendedWorkflow": {
+      "id": "evaluate",
+      "label": "Evaluate Skill",
+      "chatPrompt": "Evaluate this skill.",
+      "summary": "Start here when you want the overall report for a skill, including structure, budgets, and code checks.",
+      "firstCommand": "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+      "commands": [
+        "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown"
+      ],
+      "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Evaluate this skill.' --format markdown"
+    },
+    "workflowStatus": {
+      "hasBenchmarkConfig": false,
+      "hasUsageLog": false
+    },
+    "beginnerSummary": "Start with a natural chat request, then let plugin-eval show the exact local command sequence behind it.",
+    "startHere": {
+      "chatPrompt": "Evaluate this skill.",
+      "label": "Evaluate Skill",
+      "summary": "Start here when you want the overall report for a skill, including structure, budgets, and code checks.",
+      "routingExplanation": "Plugin Eval recommended Evaluate Skill from the current local state for this skill.",
+      "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Evaluate this skill.' --format markdown",
+      "firstCommand": "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+      "commands": [
+        "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown"
+      ]
+    },
+    "entrypoints": [
+      {
+        "id": "analysis",
+        "label": "Full Skill Analysis",
+        "chatPrompt": "Give me a full analysis of this skill, including benchmark setup.",
+        "summary": "Use this when you want the full report and starter benchmark setup for this skill in one guided path.",
+        "firstCommand": "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+        "commands": [
+          "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+          "plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+          "plugin-eval benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --config ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/.plugin-eval/benchmark.json"
+        ],
+        "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Give me a full analysis of this skill, including benchmark setup.' --format markdown"
+      },
+      {
+        "id": "evaluate",
+        "label": "Evaluate Skill",
+        "chatPrompt": "Evaluate this skill.",
+        "summary": "Start here when you want the overall report for a skill, including structure, budgets, and code checks.",
+        "firstCommand": "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+        "commands": [
+          "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown"
+        ],
+        "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Evaluate this skill.' --format markdown"
+      },
+      {
+        "id": "budget",
+        "label": "Explain Token Budget",
+        "chatPrompt": "Explain the token budget for this skill.",
+        "summary": "Use this when the main question is why the skill feels expensive before you collect any live measurements.",
+        "firstCommand": "plugin-eval explain-budget ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+        "commands": [
+          "plugin-eval explain-budget ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown"
+        ],
+        "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Explain the token budget for this skill.' --format markdown"
+      },
+      {
+        "id": "measure",
+        "label": "Measure Real Token Usage",
+        "chatPrompt": "Measure the real token usage of this skill.",
+        "summary": "Use this when you want real token usage instead of only the static estimate.",
+        "firstCommand": "plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+        "commands": [
+          "plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+          "plugin-eval benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --config ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/.plugin-eval/benchmark.json",
+          "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --observed-usage ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/.plugin-eval/benchmark-usage.jsonl --format markdown"
+        ],
+        "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Measure the real token usage of this skill.' --format markdown"
+      },
+      {
+        "id": "benchmark",
+        "label": "Benchmark With Starter Scenarios",
+        "chatPrompt": "Help me benchmark this skill.",
+        "summary": "Use this when you want starter scenarios and a repeatable real-Codex benchmark run for this skill.",
+        "firstCommand": "plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+        "commands": [
+          "plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching"
+        ],
+        "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Help me benchmark this skill.' --format markdown"
+      },
+      {
+        "id": "next",
+        "label": "Start Here",
+        "chatPrompt": "What should I run next?",
+        "summary": "If you are new to plugin-eval, start with the overall evaluation report for this skill.",
+        "firstCommand": "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+        "commands": [
+          "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown"
+        ],
+        "startCommand": "plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'What should I run next?' --format markdown"
+      }
+    ],
+    "nextSteps": [
+      "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown"
+    ],
+    "nextAction": {
+      "label": "Evaluate Skill",
+      "why": "Plugin Eval recommended Evaluate Skill from the current local state for this skill.",
+      "command": "plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown",
+      "chatPrompt": "Evaluate this skill."
+    }
+  }
+}

--- a/docs/superpowers/specs/2026-08-13-plugin-eval-before.md
+++ b/docs/superpowers/specs/2026-08-13-plugin-eval-before.md
@@ -1,0 +1,142 @@
+# Plugin Eval Report: audit-prompt-caching
+
+## At a Glance
+- Score: 54/100
+- Grade: F
+- Risk: high
+- Checks: 2 fail, 4 warn, 2 info
+- Active budget: 6022 tokens (heavy)
+- Observed usage: not supplied
+
+## Why It Matters
+- 2 failing error checks are driving the highest-confidence problems.
+- 4 warning signals still need cleanup before this feels polished.
+- budget is the largest source of score loss at -32.5 points.
+- Active budget pressure is high enough that token cost may dominate the user experience.
+- No observed usage is attached yet, so budget conclusions are still based on static estimates.
+
+## Fix First
+- [fail/error] deferred_cost_tokens is excessive relative to the current Codex baseline. Why: Budget pressure matters because always-loaded or frequently-loaded text can make the workflow feel expensive fast. Fix: Reduce repeated instruction text and move detail into deferred supporting files.
+- [fail/error] trigger_cost_tokens is excessive relative to the current Codex baseline. Why: Budget pressure matters because always-loaded or frequently-loaded text can make the workflow feel expensive fast. Fix: Reduce repeated instruction text and move detail into deferred supporting files.
+- [warn/warning] invoke_cost_tokens is heavy relative to the current Codex baseline. Why: Budget pressure matters because always-loaded or frequently-loaded text can make the workflow feel expensive fast. Fix: Reduce repeated instruction text and move detail into deferred supporting files.
+
+## Recommended Next Step
+- Measure real token usage next
+- Why: The static budget looks heavy, so live usage is the fastest way to confirm whether the cost is acceptable.
+- Chat request: "Measure the real token usage of this skill."
+- Local command: `plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Measure the real token usage of this skill.' --format markdown`
+
+## Details
+<details>
+<summary>Watch next</summary>
+
+- [warn/warning] Python source files were found without matching test files. Why: Best-practice gaps usually do not break the workflow immediately, but they make the skill harder to understand and improve. Fix: Add `test_*.py` or `tests/` coverage for the main Python logic.
+- [warn/warning] At least one Python function has high cyclomatic complexity. Why: Complexity findings matter because they increase review cost and make generated or helper code harder to change safely. Fix: Split complex functions into smaller helpers or guard clauses.
+- [warn/warning] At least one Python function is long enough to hurt readability. Why: Readability issues slow engineers down during review, debugging, and follow-up edits. Fix: Break large functions into smaller helpers with clear names.
+</details>
+<details>
+<summary>Improvement brief</summary>
+
+- Raise the evaluation from grade F (54/100) with a focus on the highest-signal structural and budget issues first.
+- Goal: Reduce repeated instruction text and move detail into deferred supporting files.
+- Goal: Split complex functions into smaller helpers or guard clauses.
+- Goal: Break large functions into smaller helpers with clear names.
+- Measure: token-usage-observer
+- Measure: task-outcome-scorecard
+- Measure: latency-efficiency
+- Suggested prompt: Use the skill-creator guidance to improve audit-prompt-caching. Keep the structure compact and move bulky details into references or scripts. Define success measures with these toolsets: token-usage-observer, task-outcome-scorecard, latency-efficiency. Address trigger_cost_tokens-budget-high: trigger_cost_tokens is excessive relative to the current Codex baseline. Address deferred_cost_tokens-budget-high: deferred_cost_tokens is excessive relative to the current Codex baseline. Address invoke_cost_tokens-budget-high: invoke_cost_tokens is heavy relative to the current Codex baseline. Address py-complexity-high: At least one Python function has high cyclomatic complexity. Address py-function-length-high: At least one Python function is long enough to hurt readability. Address py-tests-missing: Python source files were found without matching test files.
+</details>
+<details>
+<summary>Budgets and observed usage</summary>
+
+- trigger_cost_tokens: 170 (excessive)
+- invoke_cost_tokens: 5852 (heavy)
+- deferred_cost_tokens: 37740 (excessive)
+- total_tokens: 43762 (excessive)
+
+- No observed usage supplied.
+</details>
+<details>
+<summary>Measurement plan</summary>
+
+Combine cost, outcome, and trust signals so you can tell whether the skill or plugin is genuinely helping instead of only looking well-structured on paper.
+
+- Token Usage Observer [high] Measure how many tokens the skill or plugin actually burns in representative runs. Signals: observed_usage_sample_count, observed_input_tokens_avg, observed_total_tokens_avg, estimate_vs_observed_input_ratio. Evidence: Responses API usage logs, Codex-like session exports, JSONL traces captured from local benchmarking harnesses.
+- Task Outcome Scorecard [high] Measure whether the skill helps users finish the intended job with fewer retries and less cleanup. Signals: task_success_rate, first_pass_success_rate, retry_rate, human_override_rate. Evidence: Task run logs, Structured user acceptance checklist, Before/after comparison runs on the same prompts.
+- Tool Call Audit [medium] Check whether the agent uses the right tools, arguments, and sequencing when the skill is active. Signals: tool_call_success_rate, invalid_tool_argument_rate, recoverable_tool_failure_rate. Evidence: Tool invocation traces, Recorded sessions, Golden-path scenario replays.
+- Latency And Efficiency [high] Track whether the skill speeds users up enough to justify its cost. Signals: p50_time_to_first_acceptable_answer_seconds, p95_time_to_task_completion_seconds, tokens_per_successful_run. Evidence: Benchmark harness timings, Manual stopwatch runs on canonical tasks, Responses API timestamps combined with usage logs.
+- Human Rubric Review [medium] Capture clarity, trust, and usefulness signals that automated checks will miss. Signals: clarity_score_avg, confidence_score_avg, follow_up_question_rate. Evidence: Reviewer scorecards, Team rubric sheets, Annotated transcripts.
+- Regression Suite [medium] Protect the repository behavior that the skill is supposed to improve. Signals: test_pass_rate, lint_pass_rate, regression_escape_count. Evidence: Unit and integration test runs, Coverage deltas, Snapshot or golden-file checks.
+</details>
+<details>
+<summary>Use From Codex Chat</summary>
+
+Start with a natural chat request, then let plugin-eval show the exact local command sequence behind it.
+
+Start with this chat request: "Evaluate this skill."
+Why this path: Plugin Eval recommended Evaluate Skill from the current local state for this skill.
+Quick local entrypoint: plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Evaluate this skill.' --format markdown
+Plugin Eval will run first: plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+
+Other chat requests you can use:
+- Full Skill Analysis: say "Give me a full analysis of this skill, including benchmark setup." -> plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+- Evaluate Skill: say "Evaluate this skill." -> plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+- Explain Token Budget: say "Explain the token budget for this skill." -> plugin-eval explain-budget ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+- Measure Real Token Usage: say "Measure the real token usage of this skill." -> plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching
+- Benchmark With Starter Scenarios: say "Help me benchmark this skill." -> plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching
+- Start Here: say "What should I run next?" -> plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+</details>
+<details>
+<summary>Checks</summary>
+
+- [FAIL] trigger_cost_tokens-budget-high: trigger_cost_tokens is excessive relative to the current Codex baseline. Evidence: Value: 170 tokens Baseline samples: skills=12, plugins=176 Remediation: Reduce repeated instruction text and move detail into deferred supporting files.
+- [WARN] invoke_cost_tokens-budget-high: invoke_cost_tokens is heavy relative to the current Codex baseline. Evidence: Value: 5852 tokens Baseline samples: skills=12, plugins=176 Remediation: Reduce repeated instruction text and move detail into deferred supporting files.
+- [FAIL] deferred_cost_tokens-budget-high: deferred_cost_tokens is excessive relative to the current Codex baseline. Evidence: Value: 37740 tokens Baseline samples: skills=12, plugins=176 Remediation: Reduce repeated instruction text and move detail into deferred supporting files.
+- [WARN] py-complexity-high: At least one Python function has high cyclomatic complexity. Evidence: Max complexity: 99 Remediation: Split complex functions into smaller helpers or guard clauses.
+- [WARN] py-function-length-high: At least one Python function is long enough to hurt readability. Evidence: Max function length: 118 lines Remediation: Break large functions into smaller helpers with clear names.
+- [WARN] py-tests-missing: Python source files were found without matching test files. Evidence: Source files: 8 Remediation: Add `test_*.py` or `tests/` coverage for the main Python logic.
+- [INFO] coverage-artifacts-unavailable: No coverage artifacts were found for this target. Evidence: audit-prompt-caching Remediation: Generate `lcov.info`, `coverage.xml`, or an Istanbul coverage JSON file if you want coverage scoring.
+</details>
+<details>
+<summary>Metrics</summary>
+
+- skill_line_count: 310 lines (good)
+- description_length_chars: 657 chars (moderate)
+- relative_link_count: 0 links (good)
+- code_fence_count: 3 blocks (good)
+- support_file_count: 34 files (good)
+- trigger_cost_tokens: 170 tokens (excessive)
+- invoke_cost_tokens: 5852 tokens (heavy)
+- deferred_cost_tokens: 37740 tokens (excessive)
+- py_file_count: 8 files (good)
+- py_function_count: 94 functions (good)
+- py_max_cyclomatic_complexity: 99 score (heavy)
+- py_average_function_length: 15.56 lines (good)
+- py_max_nesting_depth: 8 levels (heavy)
+- py_comment_ratio: 0.006 ratio (moderate)
+- py_test_file_count: 0 files (moderate)
+- coverage_artifact_count: 0 files (info)
+</details>
+<details>
+<summary>Score details</summary>
+
+- Starting score: 100
+- Total deductions: -46.25
+- Final score: 54
+- Risk: Contains 2 failing error checks (deferred_cost_tokens-budget-high, trigger_cost_tokens-budget-high).
+- Risk: Overall score is below 70, which the evaluator treats as high risk.
+
+- -14 points: deferred_cost_tokens-budget-high [fail/error] deferred_cost_tokens is excessive relative to the current Codex baseline.
+- -14 points: trigger_cost_tokens-budget-high [fail/error] trigger_cost_tokens is excessive relative to the current Codex baseline.
+- -4.5 points: invoke_cost_tokens-budget-high [warn/warning] invoke_cost_tokens is heavy relative to the current Codex baseline.
+- -4.5 points: py-complexity-high [warn/warning] At least one Python function has high cyclomatic complexity.
+- -4.5 points: py-function-length-high [warn/warning] At least one Python function is long enough to hurt readability.
+- -4.5 points: py-tests-missing [warn/warning] Python source files were found without matching test files.
+- -0.25 points: coverage-artifacts-unavailable [info/info] No coverage artifacts were found for this target.
+
+- budget: -32.5 points across 3 checks
+- best-practice: -4.5 points across 1 check
+- complexity: -4.5 points across 1 check
+- readability: -4.5 points across 1 check
+- coverage: -0.25 points across 1 check
+</details>

--- a/docs/superpowers/specs/2026-08-13-plugin-eval-brief.json
+++ b/docs/superpowers/specs/2026-08-13-plugin-eval-brief.json
@@ -1,0 +1,68 @@
+{
+  "title": "Improve audit-prompt-caching",
+  "target": {
+    "kind": "skill",
+    "path": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching",
+    "entryPath": "/Users/notevskii/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching/SKILL.md",
+    "name": "audit-prompt-caching",
+    "relativePath": "audit-prompt-caching"
+  },
+  "summary": "Raise the evaluation from grade F (54/100) with a focus on the highest-signal structural and budget issues first.",
+  "goals": [
+    "Reduce repeated instruction text and move detail into deferred supporting files.",
+    "Split complex functions into smaller helpers or guard clauses.",
+    "Break large functions into smaller helpers with clear names."
+  ],
+  "measurementGoals": [
+    "token-usage-observer",
+    "task-outcome-scorecard",
+    "latency-efficiency"
+  ],
+  "requiredFixes": [
+    {
+      "id": "trigger_cost_tokens-budget-high",
+      "message": "trigger_cost_tokens is excessive relative to the current Codex baseline.",
+      "remediation": [
+        "Reduce repeated instruction text and move detail into deferred supporting files."
+      ]
+    },
+    {
+      "id": "deferred_cost_tokens-budget-high",
+      "message": "deferred_cost_tokens is excessive relative to the current Codex baseline.",
+      "remediation": [
+        "Reduce repeated instruction text and move detail into deferred supporting files."
+      ]
+    }
+  ],
+  "recommendedFixes": [
+    {
+      "id": "invoke_cost_tokens-budget-high",
+      "message": "invoke_cost_tokens is heavy relative to the current Codex baseline.",
+      "remediation": [
+        "Reduce repeated instruction text and move detail into deferred supporting files."
+      ]
+    },
+    {
+      "id": "py-complexity-high",
+      "message": "At least one Python function has high cyclomatic complexity.",
+      "remediation": [
+        "Split complex functions into smaller helpers or guard clauses."
+      ]
+    },
+    {
+      "id": "py-function-length-high",
+      "message": "At least one Python function is long enough to hurt readability.",
+      "remediation": [
+        "Break large functions into smaller helpers with clear names."
+      ]
+    },
+    {
+      "id": "py-tests-missing",
+      "message": "Python source files were found without matching test files.",
+      "remediation": [
+        "Add `test_*.py` or `tests/` coverage for the main Python logic."
+      ]
+    }
+  ],
+  "suggestedPrompt": "Use the skill-creator guidance to improve audit-prompt-caching. Keep the structure compact and move bulky details into references or scripts. Define success measures with these toolsets: token-usage-observer, task-outcome-scorecard, latency-efficiency. Address trigger_cost_tokens-budget-high: trigger_cost_tokens is excessive relative to the current Codex baseline. Address deferred_cost_tokens-budget-high: deferred_cost_tokens is excessive relative to the current Codex baseline. Address invoke_cost_tokens-budget-high: invoke_cost_tokens is heavy relative to the current Codex baseline. Address py-complexity-high: At least one Python function has high cyclomatic complexity. Address py-function-length-high: At least one Python function is long enough to hurt readability. Address py-tests-missing: Python source files were found without matching test files."
+}

--- a/docs/superpowers/specs/2026-08-13-plugin-eval-compare.md
+++ b/docs/superpowers/specs/2026-08-13-plugin-eval-compare.md
@@ -1,0 +1,34 @@
+# Plugin Eval Comparison: audit-prompt-caching
+
+## At a Glance
+- Score delta: +14
+- Grade: F -> D
+- Risk: high -> high
+- Budget delta (trigger/invoke/deferred): -35 / -2 / +3498
+
+## Why It Matters
+- Score delta: +14.
+- Grade moved from F to D.
+- Risk moved from high to high.
+- 1 failure were resolved.
+
+## Fix First
+- No new failures were introduced.
+
+## Recommended Next Step
+- Continue from the improved baseline
+- Why: The comparison is trending in the right direction, so the next move is to keep the workflow tight and repeatable.
+- Chat request: "What should I run next?"
+- Local command: `plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'What should I run next?' --format markdown`
+
+## Details
+<details>
+<summary>Resolved failures</summary>
+
+- trigger_cost_tokens-budget-high
+</details>
+<details>
+<summary>New failures</summary>
+
+- No new failures.
+</details>

--- a/docs/superpowers/specs/2026-08-13-plugin-eval-route.md
+++ b/docs/superpowers/specs/2026-08-13-plugin-eval-route.md
@@ -1,0 +1,38 @@
+# Plugin Eval Start Here: audit-prompt-caching
+
+## At a Glance
+- Recommended path: Evaluate Skill
+- Benchmark config present: no
+- Usage log present: no
+- Quick local entrypoint: `plugin-eval start ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --request 'Evaluate this skill against the draft cache audit evidence contract: provider field provenance, denominator validity, explicit cache planes, and a no-score clinic summary.' --format markdown`
+- First local command: `plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown`
+
+## Why It Matters
+- Start with a natural chat request, then let plugin-eval show the exact local command sequence behind it.
+- Plugin Eval routed "Evaluate this skill against the draft cache audit evidence contract: provider field provenance, denominator validity, explicit cache planes, and a no-score clinic summary." to Evaluate Skill because it asks for the overall evaluation report or prioritized findings from it.
+
+## Fix First
+- Start with the recommended path before branching into secondary workflows.
+
+## Recommended Next Step
+- Evaluate Skill
+- Why: Plugin Eval routed "Evaluate this skill against the draft cache audit evidence contract: provider field provenance, denominator validity, explicit cache planes, and a no-score clinic summary." to Evaluate Skill because it asks for the overall evaluation report or prioritized findings from it.
+- Chat request: "Evaluate this skill against the draft cache audit evidence contract: provider field provenance, denominator validity, explicit cache planes, and a no-score clinic summary."
+- Local command: `plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown`
+
+## Details
+<details>
+<summary>Full local sequence</summary>
+
+- plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+</details>
+<details>
+<summary>Other chat requests</summary>
+
+- Full Skill Analysis: "Give me a full analysis of this skill, including benchmark setup." -> plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+- Evaluate Skill: "Evaluate this skill." -> plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+- Explain Token Budget: "Explain the token budget for this skill." -> plugin-eval explain-budget ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+- Measure Real Token Usage: "Measure the real token usage of this skill." -> plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching
+- Benchmark With Starter Scenarios: "Help me benchmark this skill." -> plugin-eval init-benchmark ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching
+- Start Here: "What should I run next?" -> plugin-eval analyze ~/.config/superpowers/worktrees/audit-prompt/cache-audit-report-contract/audit-prompt-caching --format markdown
+</details>

--- a/fixtures/expected/report_openai.md
+++ b/fixtures/expected/report_openai.md
@@ -18,6 +18,18 @@
 - Do first: analyze usage logs and validate prefix stability
 - Do not do yet: make provider/routing changes without telemetry
 
+## Cache Clinic Summary
+
+- Cache planes: unknown
+- Applicability: unknown
+- Evidence quality: unknown
+- Prefix stability: unknown
+- Usage accounting: unknown
+- Routing locality: unknown
+- Economics: unknown
+- Isolation: unknown
+- Usage denominator status: valid
+
 ## Findings
 
 fixtures/openai/repeated_prefix_usage.jsonl:1 | low | openai | cold request has zero cached tokens | first request pays full prefill | warm repeated prefix before measuring steady state | confirm warm cached_tokens increase

--- a/fixtures/expected/usage_summary_openai.json
+++ b/fixtures/expected/usage_summary_openai.json
@@ -10,6 +10,7 @@
   "total_input_tokens": 15600,
   "output_tokens": 1205,
   "warnings": [],
+  "denominator_status": "valid",
   "accounting_semantics": "inclusive",
   "cache_hit_ratio": 0.5962,
   "cache_write_read_ratio": 0.0,

--- a/tests/test_prompt_cache_scripts.py
+++ b/tests/test_prompt_cache_scripts.py
@@ -1,6 +1,7 @@
 import csv
 import importlib.util
 import json
+import math
 import subprocess
 import sys
 import tempfile
@@ -11,6 +12,17 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "audit-prompt-caching" / "scripts"
 FIXTURES = ROOT / "fixtures"
+
+# plugin-eval 0.1.2 reports static token estimates as len(text) / 4. Mirroring
+# that arithmetic keeps the budget guardrails in-suite without shelling out to
+# plugin-eval, which is not a repository test dependency.
+PLUGIN_EVAL_TRIGGER_TOKEN_BUDGET = 139
+PLUGIN_EVAL_SKILL_TOKEN_BASELINE = 5852
+BASELINE_DESCRIPTION_CHARS = 679
+
+
+def estimated_plugin_eval_tokens(text):
+    return math.ceil(len(text) / 4)
 
 
 def run_script(script_name, *args):
@@ -2761,6 +2773,215 @@ class PromptCacheScriptsTest(unittest.TestCase):
         ]:
             self.assertIn(required, reference)
 
+
+    def skill_text(self):
+        return (ROOT / "audit-prompt-caching" / "SKILL.md").read_text()
+
+    def skill_frontmatter_description(self):
+        frontmatter = self.skill_text().split("---", 2)[1]
+        self.assertIn("description:", frontmatter)
+        return frontmatter.split("description:", 1)[1]
+
+    def test_skill_description_is_shorter_but_keeps_trigger_boundaries(self):
+        description = self.skill_frontmatter_description()
+
+        self.assertLessEqual(
+            estimated_plugin_eval_tokens(description),
+            PLUGIN_EVAL_TRIGGER_TOKEN_BUDGET,
+            "frontmatter description exceeds the plugin-eval moderate trigger ceiling",
+        )
+        self.assertLess(
+            len(description),
+            BASELINE_DESCRIPTION_CHARS * 0.85,
+            "frontmatter description is not materially shorter than the baseline",
+        )
+
+        for required in [
+            "Use whenever the user mentions",
+            "cached_tokens=0",
+            "cache_read_input_tokens",
+            "cache_write_tokens",
+            "prompt_cache_key",
+            "prompt_cache_options",
+            "cache_control",
+            "cachePoint",
+            "TTFT",
+            "KV reuse",
+            "LLM cost or speed regressed",
+            "repeated long prompts",
+            "speeding up agents",
+            "LLM request shape",
+            "response_format",
+            "agent loops",
+            "compaction",
+            "Not for generic prompt writing",
+            "RAG",
+            "token counts",
+            "non-LLM perf",
+        ]:
+            self.assertIn(required, description)
+
+    def test_skill_stays_within_invoked_token_baseline(self):
+        self.assertLessEqual(
+            estimated_plugin_eval_tokens(self.skill_text()),
+            PLUGIN_EVAL_SKILL_TOKEN_BASELINE,
+            "SKILL.md grew above the plugin-eval invoked-token baseline",
+        )
+
+    def test_skill_defines_explicit_cache_plane_gate(self):
+        skill = self.skill_text()
+
+        for required in [
+            "Cache Plane Gate",
+            "gateway_response",
+            "provider_prompt",
+            "engine_kv",
+            "external_kv",
+            "semantic_response",
+            "several planes at once",
+            "Do not infer a plane from provider or model names",
+        ]:
+            self.assertIn(required, skill)
+
+    def test_skill_defines_usage_evidence_contract(self):
+        skill = self.skill_text()
+
+        for required in [
+            "Usage Evidence Contract",
+            "schema_version",
+            "source_fields",
+            "accounting_semantics",
+            "denominator_status",
+            "`warnings`",
+            "decision-grade",
+            "valid",
+            "ambiguous",
+            "invalid",
+            "Do not build a second normalizer",
+        ]:
+            self.assertIn(required, skill)
+
+    def test_skill_defines_no_score_clinic_summary(self):
+        skill = self.skill_text()
+
+        for required in [
+            "Cache Clinic Summary",
+            "applicability",
+            "evidence_quality",
+            "prefix_stability",
+            "usage_accounting",
+            "routing_locality",
+            "economics",
+            "isolation",
+            "pass/warning/fail/unknown/not_applicable",
+            "Leave every unproven dimension `unknown`",
+            "never aggregate them into a score, rank, or grade",
+        ]:
+            self.assertIn(required, skill)
+
+    def test_skill_bounds_prefix_plan_and_isolation_evidence(self):
+        skill = self.skill_text()
+
+        for required in [
+            "observed rendered payload",
+            "request-construction",
+            "universal provider-internal serialization order",
+            "Isolation review is passive",
+            "separate authorization",
+            "out of scope",
+        ]:
+            self.assertIn(required, skill)
+
+    def test_observability_reference_documents_usage_evidence_contract(self):
+        reference = (
+            ROOT / "audit-prompt-caching" / "references" / "observability.md"
+        ).read_text()
+
+        for required in [
+            "Usage Evidence Contract",
+            "schema_version",
+            "source_fields",
+            "accounting_semantics",
+            "denominator_status",
+            "usage.prompt_tokens_details.cached_tokens",
+            "human-readable dot paths",
+            "not machine-resolvable JSONPath",
+            "dynamic map keys",
+            "Paths never contain leaf values or raw envelopes",
+            "Backward Compatibility",
+            "additive",
+            "strict JSON consumers must allow new event, summary, and report fields",
+            "aggregate and report schema versioning remains deferred",
+        ]:
+            self.assertIn(required, reference)
+
+    def test_report_template_documents_plane_and_clinic_contract(self):
+        template = (
+            ROOT / "audit-prompt-caching" / "references" / "report-template.md"
+        ).read_text()
+
+        for required in [
+            "Cache Planes",
+            "--cache-plane",
+            "repeatable",
+            "gateway_response",
+            "provider_prompt",
+            "engine_kv",
+            "external_kv",
+            "semantic_response",
+            "Cache Clinic Summary",
+            "applicability",
+            "evidence_quality",
+            "prefix_stability",
+            "usage_accounting",
+            "routing_locality",
+            "economics",
+            "isolation",
+            "pass/warning/fail/unknown/not_applicable",
+            "--usage-accounting",
+            "--evidence-quality",
+            "non-decision-grade",
+            "no aggregate score",
+        ]:
+            self.assertIn(required, template)
+
+    def test_readme_documents_cache_plane_and_clinic_flags(self):
+        readme = (ROOT / "README.md").read_text()
+
+        for required in [
+            "--cache-plane gateway_response",
+            "--cache-plane provider_prompt",
+            "--evidence-quality",
+            "--usage-accounting",
+            "non-decision-grade",
+            "no aggregate score",
+        ]:
+            self.assertIn(required, readme)
+
+    def test_evals_cover_plane_denominator_and_unknown_dimension_pressure(self):
+        evals = json.loads(
+            (ROOT / "audit-prompt-caching" / "evals" / "evals.json").read_text()
+        )
+        combined = "\n".join(
+            item["prompt"] + "\n" + item["expected_output"] for item in evals["evals"]
+        )
+
+        for required in [
+            "gateway response-cache hit rate",
+            "cached_tokens stays 0",
+            "gateway_response",
+            "provider_prompt",
+            "unknown OpenAI-compatible wrapper",
+            "95 percent cache hit rate",
+            "denominator_status",
+            "ambiguous",
+            "no savings claim",
+            "no usage logs",
+            "cache clinic summary",
+            "unknown",
+            "no aggregate score",
+        ]:
+            self.assertIn(required, combined)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_prompt_cache_scripts.py
+++ b/tests/test_prompt_cache_scripts.py
@@ -1497,6 +1497,199 @@ class PromptCacheScriptsTest(unittest.TestCase):
             },
         },
     )
+    UNKNOWN_WRAPPER_USAGE_RECORDS = (
+        {
+            "data": {
+                "usage": {
+                    "prompt_tokens": 1000,
+                    "cached_tokens": 600,
+                    "completion_tokens": 50,
+                }
+            }
+        },
+    )
+    CONTRADICTORY_WRAPPER_USAGE_RECORDS = (
+        {
+            "data": {
+                "usage": {
+                    "prompt_tokens": 100,
+                    "cached_tokens": 900,
+                    "completion_tokens": 10,
+                }
+            }
+        },
+    )
+    VALID_USAGE_RECORDS = (
+        {
+            "provider": "anthropic",
+            "usage": {
+                "input_tokens": 400,
+                "cache_read_input_tokens": 600,
+                "cache_creation_input_tokens": 100,
+                "output_tokens": 50,
+            },
+        },
+    )
+    ROI_JSON = {
+        "producer": "estimate_cache_roi.py",
+        "schema_version": 1,
+        "pricing": {},
+        "cache_read_input_cost": 0.1,
+        "cache_write_input_cost": 0.0,
+        "total_baseline_cost": 1.0,
+        "total_with_cache_cost": 0.5,
+        "total_savings": 0.5,
+    }
+
+    def write_roi_json(self, directory):
+        path = Path(directory) / "roi.json"
+        path.write_text(json.dumps(self.ROI_JSON))
+        return path
+
+    def test_render_audit_report_keeps_unknown_wrapper_ambiguous_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            usage_path = self.write_usage_log(
+                tmp, self.UNKNOWN_WRAPPER_USAGE_RECORDS
+            )
+            json_result = run_script(
+                "render_audit_report.py", "--json", "--usage-log", usage_path
+            )
+            pass_result = run_script(
+                "render_audit_report.py",
+                "--usage-log",
+                usage_path,
+                "--usage-accounting",
+                "pass",
+            )
+
+        self.assertEqual(json_result.returncode, 0, json_result.stderr)
+        output = json.loads(json_result.stdout)
+        self.assertEqual(output["usage"]["denominator_status"], "ambiguous")
+        self.assertEqual(output["clinic_summary"]["usage_accounting"], "warning")
+        self.assertEqual(pass_result.returncode, 2, pass_result.stdout)
+        self.assertIn("usage_accounting", pass_result.stderr)
+
+    def test_render_audit_report_accepts_operator_supplied_accounting_mode(self):
+        for mode in ("inclusive", "additive"):
+            with self.subTest(mode=mode):
+                with tempfile.TemporaryDirectory() as tmp:
+                    usage_path = self.write_usage_log(
+                        tmp, self.UNKNOWN_WRAPPER_USAGE_RECORDS
+                    )
+                    result = run_script(
+                        "render_audit_report.py",
+                        "--json",
+                        "--usage-log",
+                        usage_path,
+                        "--accounting-mode",
+                        mode,
+                        "--usage-accounting",
+                        "pass",
+                    )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                output = json.loads(result.stdout)
+                self.assertEqual(output["usage"]["denominator_status"], "valid")
+                self.assertEqual(
+                    output["clinic_summary"]["usage_accounting"], "pass"
+                )
+
+    def test_render_audit_report_rejects_pass_on_inclusive_contradiction(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            usage_path = self.write_usage_log(
+                tmp, self.CONTRADICTORY_WRAPPER_USAGE_RECORDS
+            )
+            json_result = run_script(
+                "render_audit_report.py",
+                "--json",
+                "--usage-log",
+                usage_path,
+                "--accounting-mode",
+                "inclusive",
+            )
+            pass_result = run_script(
+                "render_audit_report.py",
+                "--usage-log",
+                usage_path,
+                "--accounting-mode",
+                "inclusive",
+                "--usage-accounting",
+                "pass",
+            )
+
+        self.assertEqual(json_result.returncode, 0, json_result.stderr)
+        output = json.loads(json_result.stdout)
+        self.assertEqual(output["usage"]["denominator_status"], "invalid")
+        self.assertEqual(output["clinic_summary"]["usage_accounting"], "fail")
+        self.assertEqual(pass_result.returncode, 2, pass_result.stdout)
+        self.assertIn("usage_accounting", pass_result.stderr)
+
+    def test_render_audit_report_rejects_unknown_accounting_mode(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            usage_path = self.write_usage_log(
+                tmp, self.UNKNOWN_WRAPPER_USAGE_RECORDS
+            )
+            result = run_script(
+                "render_audit_report.py",
+                "--usage-log",
+                usage_path,
+                "--accounting-mode",
+                "guess",
+            )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("--accounting-mode", result.stderr)
+        self.assertIn("invalid choice", result.stderr)
+
+    def test_render_audit_report_qualifies_cost_lines_on_bad_denominator(self):
+        cases = (
+            (self.AMBIGUOUS_USAGE_RECORDS, "ambiguous"),
+            (self.INVALID_USAGE_RECORDS, "invalid"),
+        )
+        for records, denominator in cases:
+            with self.subTest(denominator=denominator):
+                with tempfile.TemporaryDirectory() as tmp:
+                    usage_path = self.write_usage_log(tmp, records)
+                    roi_path = self.write_roi_json(tmp)
+                    result = run_script(
+                        "render_audit_report.py",
+                        "--usage-log",
+                        usage_path,
+                        "--roi-json",
+                        roi_path,
+                    )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                qualifier = (
+                    f"(usage ratio non-decision-grade; denominator {denominator})"
+                )
+                self.assertIn(
+                    f"- Cost impact: savings of $0.500000 {qualifier}",
+                    result.stdout,
+                )
+                self.assertIn(
+                    f"- Assessment: savings of $0.500000 {qualifier}",
+                    result.stdout,
+                )
+                self.assertIn("estimates $0.500000 in savings", result.stdout)
+                self.assertIn("must not support a savings claim", result.stdout)
+
+    def test_render_audit_report_keeps_plain_cost_lines_on_valid_denominator(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            usage_path = self.write_usage_log(tmp, self.VALID_USAGE_RECORDS)
+            roi_path = self.write_roi_json(tmp)
+            result = run_script(
+                "render_audit_report.py",
+                "--usage-log",
+                usage_path,
+                "--roi-json",
+                roi_path,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("- Cost impact: savings of $0.500000\n", result.stdout)
+        self.assertIn("- Assessment: savings of $0.500000\n", result.stdout)
+        self.assertNotIn("non-decision-grade", result.stdout)
 
     def test_render_audit_report_canonicalizes_cache_planes_and_clinic_statuses(self):
         result = run_script(
@@ -2820,6 +3013,25 @@ class PromptCacheScriptsTest(unittest.TestCase):
             "non-LLM perf",
         ]:
             self.assertIn(required, description)
+
+    def test_skill_description_keeps_provider_telemetry_anchors(self):
+        description = self.skill_frontmatter_description()
+        body = self.skill_text().split("---", 2)[2]
+
+        for anchor in [
+            "total_cached_tokens",
+            "cache_creation_input_tokens",
+            "prompt_cache_breakpoint",
+            "previous_interaction_id",
+        ]:
+            with self.subTest(anchor=anchor):
+                self.assertIn(
+                    anchor,
+                    description,
+                    f"{anchor} must be a frontmatter trigger anchor, not body-only",
+                )
+
+        self.assertNotIn("description:", body)
 
     def test_skill_stays_within_invoked_token_baseline(self):
         self.assertLessEqual(

--- a/tests/test_prompt_cache_scripts.py
+++ b/tests/test_prompt_cache_scripts.py
@@ -207,6 +207,19 @@ class PromptCacheScriptsTest(unittest.TestCase):
         self.assertEqual(events[1]["cache_benefit_tokens"], 4600)
         self.assertEqual(events[1]["total_input_tokens"], 5200)
         self.assertEqual(events[2]["output_tokens"], 405)
+        self.assertEqual(events[0]["schema_version"], 1)
+        self.assertEqual(
+            events[0]["source_fields"],
+            {
+                "input_tokens": "usage.input_tokens",
+                "cached_tokens": "usage.input_tokens_details.cached_tokens",
+                "cache_read_input_tokens": None,
+                "cache_creation_input_tokens": None,
+                "cache_write_tokens": None,
+                "output_tokens": "usage.output_tokens",
+            },
+        )
+        self.assertEqual(events[0]["denominator_status"], "valid")
 
     def test_analyze_usage_logs_uses_full_anthropic_denominator(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -623,6 +636,281 @@ class PromptCacheScriptsTest(unittest.TestCase):
             output["warnings"][0]["code"],
             "OPENAI_CACHE_BREAKDOWN_EXCEEDS_INPUT",
         )
+        self.assertEqual(output["denominator_status"], "invalid")
+        self.assertNotIn("schema_version", output)
+
+    def normalized_event(self, record, *args, name="usage.json"):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / name
+            log_path.write_text(json.dumps(record))
+            result = run_script(
+                "analyze_usage_logs.py", "--jsonl-normalized", *args, log_path
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return json.loads(result.stdout)
+
+    def test_analyze_usage_logs_reports_openai_chat_usage_provenance(self):
+        event = self.normalized_event(
+            {
+                "provider": "openai",
+                "usage": {
+                    "prompt_tokens": 1200,
+                    "prompt_tokens_details": {
+                        "cached_tokens": 700,
+                        "cache_write_tokens": 300,
+                    },
+                    "completion_tokens": 80,
+                },
+            }
+        )
+
+        self.assertEqual(
+            event["source_fields"],
+            {
+                "input_tokens": "usage.prompt_tokens",
+                "cached_tokens": "usage.prompt_tokens_details.cached_tokens",
+                "cache_read_input_tokens": None,
+                "cache_creation_input_tokens": None,
+                "cache_write_tokens": "usage.prompt_tokens_details.cache_write_tokens",
+                "output_tokens": "usage.completion_tokens",
+            },
+        )
+        self.assertEqual(event["denominator_status"], "valid")
+
+    def test_analyze_usage_logs_reports_anthropic_usage_provenance(self):
+        event = self.normalized_event(
+            {
+                "usage": {
+                    "input_tokens": 500,
+                    "cache_read_input_tokens": 300,
+                    "cache_creation_input_tokens": 200,
+                    "output_tokens": 50,
+                }
+            }
+        )
+
+        self.assertEqual(
+            event["source_fields"],
+            {
+                "input_tokens": "usage.input_tokens",
+                "cached_tokens": None,
+                "cache_read_input_tokens": "usage.cache_read_input_tokens",
+                "cache_creation_input_tokens": "usage.cache_creation_input_tokens",
+                "cache_write_tokens": None,
+                "output_tokens": "usage.output_tokens",
+            },
+        )
+        self.assertEqual(event["accounting_semantics"], "additive")
+        self.assertEqual(event["denominator_status"], "valid")
+
+    def test_analyze_usage_logs_reports_bedrock_metrics_provenance(self):
+        event = self.normalized_event(
+            {
+                "metrics": {
+                    "InputTokens": 1000,
+                    "CacheReadInputTokens": 400,
+                    "CacheWriteInputTokens": 200,
+                    "OutputTokens": 100,
+                }
+            }
+        )
+
+        self.assertEqual(
+            event["source_fields"],
+            {
+                "input_tokens": "metrics.InputTokens",
+                "cached_tokens": None,
+                "cache_read_input_tokens": "metrics.CacheReadInputTokens",
+                "cache_creation_input_tokens": "metrics.CacheWriteInputTokens",
+                "cache_write_tokens": None,
+                "output_tokens": "metrics.OutputTokens",
+            },
+        )
+        self.assertEqual(event["denominator_status"], "valid")
+
+    def test_analyze_usage_logs_reports_bedrock_converse_provenance(self):
+        event = self.normalized_event(
+            {
+                "provider": "bedrock",
+                "metrics": {"latencyMs": 42},
+                "usage": {
+                    "inputTokens": 1000,
+                    "cacheReadInputTokens": 400,
+                    "cacheWriteInputTokens": 200,
+                    "outputTokens": 100,
+                },
+            }
+        )
+
+        self.assertEqual(
+            event["source_fields"],
+            {
+                "input_tokens": "usage.inputTokens",
+                "cached_tokens": None,
+                "cache_read_input_tokens": "usage.cacheReadInputTokens",
+                "cache_creation_input_tokens": "usage.cacheWriteInputTokens",
+                "cache_write_tokens": None,
+                "output_tokens": "usage.outputTokens",
+            },
+        )
+        self.assertEqual(event["denominator_status"], "valid")
+
+    def test_analyze_usage_logs_reports_gemini_interactions_provenance(self):
+        event = self.normalized_event(
+            {
+                "event_type": "step.stop",
+                "metadata": {
+                    "total_usage": {
+                        "total_cached_tokens": 600,
+                        "total_input_tokens": 1000,
+                        "total_output_tokens": 100,
+                    }
+                },
+            }
+        )
+
+        self.assertEqual(
+            event["source_fields"],
+            {
+                "input_tokens": "metadata.total_usage.total_input_tokens",
+                "cached_tokens": "metadata.total_usage.total_cached_tokens",
+                "cache_read_input_tokens": None,
+                "cache_creation_input_tokens": None,
+                "cache_write_tokens": None,
+                "output_tokens": "metadata.total_usage.total_output_tokens",
+            },
+        )
+        self.assertEqual(event["denominator_status"], "valid")
+
+    def test_analyze_usage_logs_reports_gemini_generate_content_provenance(self):
+        event = self.normalized_event(
+            {
+                "provider": "gemini",
+                "usageMetadata": {
+                    "promptTokenCount": 1000,
+                    "cachedContentTokenCount": 600,
+                    "candidatesTokenCount": 100,
+                },
+            }
+        )
+
+        self.assertEqual(
+            event["source_fields"],
+            {
+                "input_tokens": "usageMetadata.promptTokenCount",
+                "cached_tokens": "usageMetadata.cachedContentTokenCount",
+                "cache_read_input_tokens": None,
+                "cache_creation_input_tokens": None,
+                "cache_write_tokens": None,
+                "output_tokens": "usageMetadata.candidatesTokenCount",
+            },
+        )
+        self.assertEqual(event["denominator_status"], "valid")
+
+    def test_analyze_usage_logs_reports_nested_wrapper_provenance(self):
+        record = {
+            "provider": "openrouter",
+            "data": {
+                "usage": {
+                    "prompt_tokens": 1000,
+                    "cached_tokens": 600,
+                    "completion_tokens": 50,
+                }
+            },
+        }
+
+        event = self.normalized_event(record)
+        overridden = self.normalized_event(record, "--accounting-mode", "inclusive")
+
+        self.assertEqual(
+            event["source_fields"],
+            {
+                "input_tokens": "data.usage.prompt_tokens",
+                "cached_tokens": "data.usage.cached_tokens",
+                "cache_read_input_tokens": None,
+                "cache_creation_input_tokens": None,
+                "cache_write_tokens": None,
+                "output_tokens": "data.usage.completion_tokens",
+            },
+        )
+        self.assertEqual(event["accounting_semantics"], "ambiguous")
+        self.assertEqual(event["denominator_status"], "ambiguous")
+        self.assertEqual(overridden["accounting_semantics"], "inclusive")
+        self.assertEqual(overridden["denominator_status"], "valid")
+
+    def test_analyze_usage_logs_marks_inclusive_contradiction_invalid(self):
+        event = self.normalized_event(
+            {
+                "provider": "gemini",
+                "usageMetadata": {
+                    "promptTokenCount": 1000,
+                    "cachedContentTokenCount": 1200,
+                    "candidatesTokenCount": 100,
+                },
+            }
+        )
+
+        self.assertEqual(event["denominator_status"], "invalid")
+        self.assertEqual(
+            event["warnings"][0]["code"],
+            "INCLUSIVE_CACHE_BREAKDOWN_EXCEEDS_INPUT",
+        )
+        self.assertEqual(event["warnings"][0]["field"], "cached_tokens")
+
+    def test_analyze_usage_logs_aggregates_worst_denominator_status(self):
+        valid_record = {
+            "provider": "openai",
+            "usage": {
+                "input_tokens": 1000,
+                "input_tokens_details": {"cached_tokens": 600},
+                "output_tokens": 50,
+            },
+        }
+        ambiguous_record = {
+            "provider": "openrouter",
+            "usage": {"input_tokens": 1000, "cached_tokens": 600},
+        }
+        invalid_record = {
+            "provider": "gemini",
+            "usageMetadata": {
+                "promptTokenCount": 100,
+                "cachedContentTokenCount": 900,
+            },
+        }
+
+        def summarize(*records):
+            with tempfile.TemporaryDirectory() as tmp:
+                log_path = Path(tmp) / "usage.jsonl"
+                log_path.write_text(
+                    "\n".join(json.dumps(record) for record in records)
+                )
+                result = run_script("analyze_usage_logs.py", log_path)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            return json.loads(result.stdout)
+
+        self.assertEqual(summarize(valid_record)["denominator_status"], "valid")
+        self.assertEqual(
+            summarize(valid_record, ambiguous_record)["denominator_status"],
+            "ambiguous",
+        )
+        self.assertEqual(
+            summarize(valid_record, ambiguous_record, invalid_record)[
+                "denominator_status"
+            ],
+            "invalid",
+        )
+
+    def test_analyze_usage_logs_reports_ambiguous_denominator_without_records(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "empty.jsonl"
+            log_path.write_text("")
+
+            result = run_script("analyze_usage_logs.py", log_path)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        output = json.loads(result.stdout)
+        self.assertEqual(output["records"], 0)
+        self.assertEqual(output["denominator_status"], "ambiguous")
 
     def test_estimate_cache_roi_outputs_cost_delta_json(self):
         result = run_script(

--- a/tests/test_prompt_cache_scripts.py
+++ b/tests/test_prompt_cache_scripts.py
@@ -1458,6 +1458,219 @@ class PromptCacheScriptsTest(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn("producer", result.stderr)
 
+    @staticmethod
+    def write_usage_log(directory, records):
+        path = Path(directory) / "usage.jsonl"
+        path.write_text("\n".join(json.dumps(record) for record in records))
+        return path
+
+    AMBIGUOUS_USAGE_RECORDS = (
+        {
+            "provider": "openai",
+            "usage": {
+                "input_tokens": 1000,
+                "input_tokens_details": {"cached_tokens": 600},
+                "output_tokens": 50,
+            },
+        },
+        {"provider": "openai", "model": "gpt-5.4", "route": "responses-api"},
+    )
+    INVALID_USAGE_RECORDS = (
+        {
+            "provider": "gemini",
+            "usageMetadata": {
+                "promptTokenCount": 100,
+                "cachedContentTokenCount": 900,
+                "candidatesTokenCount": 10,
+            },
+        },
+    )
+
+    def test_render_audit_report_canonicalizes_cache_planes_and_clinic_statuses(self):
+        result = run_script(
+            "render_audit_report.py",
+            "--json",
+            "--usage-log",
+            FIXTURES / "openai" / "repeated_prefix_usage.jsonl",
+            "--cache-plane",
+            "engine_kv",
+            "--cache-plane",
+            "gateway_response",
+            "--cache-plane",
+            "engine_kv",
+            "--cache-plane",
+            "provider_prompt",
+            "--applicability",
+            "pass",
+            "--prefix-stability",
+            "warning",
+            "--isolation",
+            "not_applicable",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        output = json.loads(result.stdout)
+        self.assertEqual(
+            output["cache_planes"],
+            ["gateway_response", "provider_prompt", "engine_kv"],
+        )
+        self.assertEqual(
+            output["clinic_summary"],
+            {
+                "applicability": "pass",
+                "evidence_quality": "unknown",
+                "prefix_stability": "warning",
+                "usage_accounting": "unknown",
+                "routing_locality": "unknown",
+                "economics": "unknown",
+                "isolation": "not_applicable",
+            },
+        )
+
+    def test_render_audit_report_markdown_renders_unknown_clinic_summary(self):
+        result = run_script(
+            "render_audit_report.py",
+            "--usage-log",
+            FIXTURES / "openai" / "repeated_prefix_usage.jsonl",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("## Cache Clinic Summary", result.stdout)
+        self.assertLess(
+            result.stdout.index("## Cache Clinic Summary"),
+            result.stdout.index("## Findings"),
+        )
+        self.assertIn("Cache planes: unknown", result.stdout)
+        for label in (
+            "Applicability",
+            "Evidence quality",
+            "Prefix stability",
+            "Usage accounting",
+            "Routing locality",
+            "Economics",
+            "Isolation",
+        ):
+            self.assertIn(f"- {label}: unknown", result.stdout)
+
+    def test_render_audit_report_rejects_invalid_clinic_choices(self):
+        usage_log = FIXTURES / "openai" / "repeated_prefix_usage.jsonl"
+
+        bad_status = run_script(
+            "render_audit_report.py",
+            "--usage-log",
+            usage_log,
+            "--economics",
+            "excellent",
+        )
+        bad_plane = run_script(
+            "render_audit_report.py",
+            "--usage-log",
+            usage_log,
+            "--cache-plane",
+            "cdn_cache",
+        )
+
+        self.assertEqual(bad_status.returncode, 2)
+        self.assertIn("--economics", bad_status.stderr)
+        self.assertIn("invalid choice", bad_status.stderr)
+        self.assertEqual(bad_plane.returncode, 2)
+        self.assertIn("--cache-plane", bad_plane.stderr)
+        self.assertIn("invalid choice", bad_plane.stderr)
+
+    def test_render_audit_report_rejects_pass_usage_accounting_on_bad_denominator(self):
+        for records in (self.AMBIGUOUS_USAGE_RECORDS, self.INVALID_USAGE_RECORDS):
+            with self.subTest(records=records):
+                with tempfile.TemporaryDirectory() as tmp:
+                    usage_path = self.write_usage_log(tmp, records)
+                    result = run_script(
+                        "render_audit_report.py",
+                        "--usage-log",
+                        usage_path,
+                        "--usage-accounting",
+                        "pass",
+                    )
+
+                self.assertEqual(result.returncode, 2, result.stdout)
+                self.assertIn("usage_accounting", result.stderr)
+
+    def test_render_audit_report_derives_usage_accounting_from_denominator(self):
+        cases = (
+            (self.AMBIGUOUS_USAGE_RECORDS, "ambiguous", "warning"),
+            (self.INVALID_USAGE_RECORDS, "invalid", "fail"),
+        )
+        for records, denominator, expected_status in cases:
+            with self.subTest(denominator=denominator):
+                with tempfile.TemporaryDirectory() as tmp:
+                    usage_path = self.write_usage_log(tmp, records)
+                    json_result = run_script(
+                        "render_audit_report.py",
+                        "--json",
+                        "--usage-log",
+                        usage_path,
+                    )
+                    markdown_result = run_script(
+                        "render_audit_report.py",
+                        "--usage-log",
+                        usage_path,
+                    )
+
+                self.assertEqual(json_result.returncode, 0, json_result.stderr)
+                output = json.loads(json_result.stdout)
+                self.assertEqual(output["usage"]["denominator_status"], denominator)
+                self.assertEqual(
+                    output["clinic_summary"]["usage_accounting"], expected_status
+                )
+                self.assertNotIn("Observed cache benefit on", output["expected_impact"])
+                self.assertIn(denominator, output["expected_impact"])
+                self.assertIn("must not support a savings claim", output["expected_impact"])
+
+                self.assertEqual(markdown_result.returncode, 0, markdown_result.stderr)
+                self.assertIn(
+                    f"- Usage accounting: {expected_status}", markdown_result.stdout
+                )
+                self.assertIn(
+                    f"Usage denominator status: {denominator}", markdown_result.stdout
+                )
+                self.assertNotIn("Observed cache benefit on", markdown_result.stdout)
+
+    def test_render_audit_report_has_no_aggregate_clinic_rollup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            usage_path = self.write_usage_log(tmp, self.INVALID_USAGE_RECORDS)
+            json_result = run_script(
+                "render_audit_report.py",
+                "--json",
+                "--usage-log",
+                usage_path,
+                "--cache-plane",
+                "engine_kv",
+                "--applicability",
+                "pass",
+            )
+            markdown_result = run_script(
+                "render_audit_report.py",
+                "--usage-log",
+                usage_path,
+                "--cache-plane",
+                "engine_kv",
+                "--applicability",
+                "pass",
+            )
+
+        self.assertEqual(json_result.returncode, 0, json_result.stderr)
+        output = json.loads(json_result.stdout)
+        forbidden = ("score", "rank", "grade", "percentage", "rollup", "traffic_light")
+        for key in list(output) + list(output["clinic_summary"]):
+            self.assertFalse(
+                any(token in key for token in forbidden),
+                f"unexpected aggregate key: {key}",
+            )
+        self.assertEqual(json_result.returncode, 0)
+
+        self.assertEqual(markdown_result.returncode, 0, markdown_result.stderr)
+        lowered = markdown_result.stdout.lower()
+        for token in ("clinic score", "overall score", "clinic grade", "clinic rank"):
+            self.assertNotIn(token, lowered)
+
     def test_extract_llm_calls_finds_provider_signals(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)

--- a/tests/test_prompt_cache_scripts.py
+++ b/tests/test_prompt_cache_scripts.py
@@ -1054,6 +1054,134 @@ class PromptCacheScriptsTest(unittest.TestCase):
         )
         self.assertEqual(event["warnings"][0]["field"], "cached_tokens")
 
+    def test_analyze_usage_logs_flags_inclusive_read_aliases_exceeding_input(self):
+        record = {
+            "data": {
+                "usage": {
+                    "prompt_tokens": 1000,
+                    "cached_tokens": 600,
+                    "cache_read_tokens": 700,
+                    "completion_tokens": 50,
+                }
+            }
+        }
+
+        event = self.normalized_event(record, "--accounting-mode", "inclusive")
+
+        self.assertEqual(event["cached_tokens"], 600)
+        self.assertEqual(event["cache_read_input_tokens"], 700)
+        self.assertEqual(event["denominator_status"], "invalid")
+        self.assertEqual(len(event["warnings"]), 1)
+        self.assertEqual(
+            event["warnings"][0]["code"],
+            "INCLUSIVE_CACHE_BREAKDOWN_EXCEEDS_INPUT",
+        )
+        self.assertEqual(event["warnings"][0]["field"], "cache_benefit_tokens")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self.write_usage_log(tmp, (record,))
+            result = run_script(
+                "analyze_usage_logs.py", "--accounting-mode", "inclusive", log_path
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        totals = json.loads(result.stdout)
+        self.assertEqual(totals["denominator_status"], "invalid")
+        self.assertEqual(totals["cache_hit_ratio"], 1.3)
+
+    def test_analyze_usage_logs_keeps_exact_inclusive_split_valid(self):
+        event = self.normalized_event(
+            {
+                "data": {
+                    "usage": {
+                        "prompt_tokens": 1000,
+                        "cached_tokens": 400,
+                        "cache_read_tokens": 600,
+                        "completion_tokens": 50,
+                    }
+                }
+            },
+            "--accounting-mode",
+            "inclusive",
+        )
+
+        self.assertEqual(event["cache_benefit_tokens"], 1000)
+        self.assertEqual(event["denominator_status"], "valid")
+        self.assertEqual(event["warnings"], [])
+
+    def test_analyze_usage_logs_flags_inclusive_write_total_exceeding_input(self):
+        event = self.normalized_event(
+            {
+                "data": {
+                    "usage": {
+                        "prompt_tokens": 1000,
+                        "cache_write_tokens": 600,
+                        "cache_creation_input_tokens": 700,
+                        "completion_tokens": 50,
+                    }
+                }
+            },
+            "--accounting-mode",
+            "inclusive",
+        )
+
+        self.assertEqual(event["denominator_status"], "invalid")
+        self.assertEqual(len(event["warnings"]), 1)
+        self.assertEqual(
+            event["warnings"][0]["code"],
+            "INCLUSIVE_CACHE_BREAKDOWN_EXCEEDS_INPUT",
+        )
+        self.assertEqual(event["warnings"][0]["field"], "cache_write_total_tokens")
+
+    def test_analyze_usage_logs_flags_inclusive_read_write_split_exceeding_input(self):
+        event = self.normalized_event(
+            {
+                "data": {
+                    "usage": {
+                        "prompt_tokens": 1000,
+                        "cached_tokens": 600,
+                        "cache_write_tokens": 600,
+                        "completion_tokens": 50,
+                    }
+                }
+            },
+            "--accounting-mode",
+            "inclusive",
+        )
+
+        self.assertEqual(event["denominator_status"], "invalid")
+        self.assertEqual(len(event["warnings"]), 1)
+        self.assertEqual(
+            event["warnings"][0]["code"],
+            "INCLUSIVE_CACHE_BREAKDOWN_EXCEEDS_INPUT",
+        )
+        self.assertEqual(
+            event["warnings"][0]["field"], "cache_accounted_input_tokens"
+        )
+
+    def test_analyze_usage_logs_prefers_individual_openai_breakdown_violation(self):
+        event = self.normalized_event(
+            {
+                "provider": "openai",
+                "usage": {
+                    "input_tokens": 100,
+                    "input_tokens_details": {
+                        "cached_tokens": 120,
+                        "cache_write_tokens": 90,
+                    },
+                    "output_tokens": 50,
+                },
+            }
+        )
+
+        self.assertEqual(event["denominator_status"], "invalid")
+        self.assertEqual(len(event["warnings"]), 1)
+        self.assertEqual(
+            event["warnings"][0]["code"],
+            "OPENAI_CACHE_BREAKDOWN_EXCEEDS_INPUT",
+        )
+        self.assertEqual(event["warnings"][0]["field"], "cached_tokens")
+
     def test_analyze_usage_logs_reports_flat_openai_provenance(self):
         event = self.normalized_event(
             {
@@ -1519,6 +1647,18 @@ class PromptCacheScriptsTest(unittest.TestCase):
             }
         },
     )
+    AGGREGATE_CONTRADICTORY_WRAPPER_USAGE_RECORDS = (
+        {
+            "data": {
+                "usage": {
+                    "prompt_tokens": 1000,
+                    "cached_tokens": 600,
+                    "cache_read_tokens": 700,
+                    "completion_tokens": 50,
+                }
+            }
+        },
+    )
     VALID_USAGE_RECORDS = (
         {
             "provider": "anthropic",
@@ -1621,6 +1761,55 @@ class PromptCacheScriptsTest(unittest.TestCase):
         output = json.loads(json_result.stdout)
         self.assertEqual(output["usage"]["denominator_status"], "invalid")
         self.assertEqual(output["clinic_summary"]["usage_accounting"], "fail")
+        self.assertEqual(pass_result.returncode, 2, pass_result.stdout)
+        self.assertIn("usage_accounting", pass_result.stderr)
+
+    def test_render_audit_report_rejects_pass_on_aggregate_inclusive_contradiction(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as tmp:
+            usage_path = self.write_usage_log(
+                tmp, self.AGGREGATE_CONTRADICTORY_WRAPPER_USAGE_RECORDS
+            )
+            json_result = run_script(
+                "render_audit_report.py",
+                "--json",
+                "--usage-log",
+                usage_path,
+                "--accounting-mode",
+                "inclusive",
+            )
+            markdown_result = run_script(
+                "render_audit_report.py",
+                "--usage-log",
+                usage_path,
+                "--accounting-mode",
+                "inclusive",
+            )
+            pass_result = run_script(
+                "render_audit_report.py",
+                "--usage-log",
+                usage_path,
+                "--accounting-mode",
+                "inclusive",
+                "--usage-accounting",
+                "pass",
+            )
+
+        self.assertEqual(json_result.returncode, 0, json_result.stderr)
+        output = json.loads(json_result.stdout)
+        self.assertEqual(output["usage"]["denominator_status"], "invalid")
+        self.assertEqual(output["usage"]["cache_hit_ratio"], 1.3)
+        self.assertEqual(output["clinic_summary"]["usage_accounting"], "fail")
+        self.assertEqual(markdown_result.returncode, 0, markdown_result.stderr)
+        self.assertIn(
+            "- Cache hit ratio: 1.3 (non-decision-grade; denominator invalid)",
+            markdown_result.stdout,
+        )
+        self.assertIn(
+            "(usage ratio non-decision-grade; denominator invalid)",
+            markdown_result.stdout,
+        )
         self.assertEqual(pass_result.returncode, 2, pass_result.stdout)
         self.assertIn("usage_accounting", pass_result.stderr)
 

--- a/tests/test_prompt_cache_scripts.py
+++ b/tests/test_prompt_cache_scripts.py
@@ -1,4 +1,5 @@
 import csv
+import importlib.util
 import json
 import subprocess
 import sys
@@ -24,6 +25,20 @@ def run_script(script_name, *args):
 
 def load_jsonl(path):
     return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def load_script_module(script_name):
+    """Import a script for module-level assertions without writing bytecode."""
+    path = SCRIPTS / script_name
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    previous = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.dont_write_bytecode = previous
+    return module
 
 
 class PromptCacheScriptsTest(unittest.TestCase):
@@ -911,6 +926,185 @@ class PromptCacheScriptsTest(unittest.TestCase):
         output = json.loads(result.stdout)
         self.assertEqual(output["records"], 0)
         self.assertEqual(output["denominator_status"], "ambiguous")
+
+    def test_analyze_usage_logs_marks_evidence_free_record_ambiguous(self):
+        evidence_free_record = {
+            "provider": "openai",
+            "model": "gpt-5.4",
+            "route": "responses-api",
+        }
+        valid_record = {
+            "provider": "openai",
+            "usage": {
+                "input_tokens": 1000,
+                "input_tokens_details": {"cached_tokens": 600},
+                "output_tokens": 50,
+            },
+        }
+
+        event = self.normalized_event(evidence_free_record)
+
+        self.assertEqual(event["denominator_status"], "ambiguous")
+        self.assertEqual(set(event["source_fields"].values()), {None})
+
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "usage.jsonl"
+            log_path.write_text(
+                "\n".join(
+                    json.dumps(record)
+                    for record in (valid_record, evidence_free_record)
+                )
+            )
+            result = run_script("analyze_usage_logs.py", log_path)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout)["denominator_status"], "ambiguous"
+        )
+
+    def test_analyze_usage_logs_keeps_additive_denominator_without_uncached_input(self):
+        event = self.normalized_event(
+            {
+                "provider": "anthropic",
+                "usage": {
+                    "input_tokens": 0,
+                    "cache_read_input_tokens": 800,
+                    "output_tokens": 40,
+                },
+            }
+        )
+
+        self.assertEqual(event["total_input_tokens"], 800)
+        self.assertEqual(event["denominator_status"], "valid")
+
+    def test_analyze_usage_logs_marks_zero_denominator_ambiguous(self):
+        event = self.normalized_event(
+            {
+                "provider": "openai",
+                "usage": {"input_tokens": 0, "output_tokens": 40},
+            }
+        )
+
+        self.assertEqual(event["total_input_tokens"], 0)
+        self.assertEqual(event["denominator_status"], "ambiguous")
+
+    def test_analyze_usage_logs_keeps_inclusive_contradiction_over_zero_input(self):
+        event = self.normalized_event(
+            {
+                "provider": "gemini",
+                "usageMetadata": {
+                    "promptTokenCount": 0,
+                    "cachedContentTokenCount": 900,
+                },
+            }
+        )
+
+        self.assertEqual(event["denominator_status"], "invalid")
+        self.assertEqual(
+            event["warnings"][0]["code"],
+            "INCLUSIVE_CACHE_BREAKDOWN_EXCEEDS_INPUT",
+        )
+
+    def test_analyze_usage_logs_keeps_zero_valued_wrapper_alias_provenance(self):
+        event = self.normalized_event(
+            {
+                "provider": "openrouter",
+                "usage": {
+                    "input_tokens": 1000,
+                    "cached_tokens": 0,
+                    "prompt_cache_hit_tokens": 0,
+                    "output_tokens": 50,
+                },
+            }
+        )
+
+        self.assertEqual(event["cached_tokens"], 0)
+        self.assertEqual(event["source_fields"]["cached_tokens"], "usage.cached_tokens")
+
+    def test_analyze_usage_logs_flags_inclusive_override_contradiction(self):
+        event = self.normalized_event(
+            {
+                "provider": "openrouter",
+                "usage": {
+                    "input_tokens": 100,
+                    "cached_tokens": 400,
+                    "output_tokens": 50,
+                },
+            },
+            "--accounting-mode",
+            "inclusive",
+        )
+
+        self.assertEqual(event["denominator_status"], "invalid")
+        self.assertEqual(
+            event["warnings"][0]["code"],
+            "INCLUSIVE_CACHE_BREAKDOWN_EXCEEDS_INPUT",
+        )
+        self.assertEqual(event["warnings"][0]["field"], "cached_tokens")
+
+    def test_analyze_usage_logs_reports_flat_openai_provenance(self):
+        event = self.normalized_event(
+            {
+                "provider": "openai",
+                "input_tokens": 1000,
+                "cached_tokens": 600,
+                "cache_write_tokens": 200,
+                "output_tokens": 50,
+            }
+        )
+
+        self.assertEqual(
+            event["source_fields"],
+            {
+                "input_tokens": "input_tokens",
+                "cached_tokens": "cached_tokens",
+                "cache_read_input_tokens": None,
+                "cache_creation_input_tokens": None,
+                "cache_write_tokens": "cache_write_tokens",
+                "output_tokens": "output_tokens",
+            },
+        )
+        self.assertEqual(event["denominator_status"], "valid")
+
+    def test_analyze_usage_logs_reports_gemini_interactions_usage_envelope_provenance(
+        self,
+    ):
+        event = self.normalized_event(
+            {
+                "provider": "gemini",
+                "usage": {
+                    "total_input_tokens": 1000,
+                    "total_cached_tokens": 600,
+                    "total_output_tokens": 100,
+                },
+            }
+        )
+
+        self.assertEqual(
+            event["source_fields"],
+            {
+                "input_tokens": "usage.total_input_tokens",
+                "cached_tokens": "usage.total_cached_tokens",
+                "cache_read_input_tokens": None,
+                "cache_creation_input_tokens": None,
+                "cache_write_tokens": None,
+                "output_tokens": "usage.total_output_tokens",
+            },
+        )
+        self.assertEqual(event["denominator_status"], "valid")
+
+    def test_analyze_usage_logs_rejects_non_canonical_extraction_fields(self):
+        analyzer = load_script_module("analyze_usage_logs.py")
+
+        with self.assertRaises(ValueError):
+            analyzer.extraction(cached_token=(600, "usage.cached_token"))
+
+        _, source_fields = analyzer.extraction(
+            cached_tokens=(600, "usage.cached_tokens")
+        )
+        self.assertEqual(
+            tuple(source_fields), tuple(analyzer.CANONICAL_USAGE_FIELDS)
+        )
 
     def test_estimate_cache_roi_outputs_cost_delta_json(self):
         result = run_script(

--- a/tests/test_prompt_cache_scripts.py
+++ b/tests/test_prompt_cache_scripts.py
@@ -1527,6 +1527,25 @@ class PromptCacheScriptsTest(unittest.TestCase):
             },
         )
 
+        markdown_result = run_script(
+            "render_audit_report.py",
+            "--usage-log",
+            FIXTURES / "openai" / "repeated_prefix_usage.jsonl",
+            "--cache-plane",
+            "engine_kv",
+            "--cache-plane",
+            "gateway_response",
+            "--cache-plane",
+            "engine_kv",
+            "--cache-plane",
+            "provider_prompt",
+        )
+        self.assertEqual(markdown_result.returncode, 0, markdown_result.stderr)
+        self.assertIn(
+            "Cache planes: gateway_response, provider_prompt, engine_kv",
+            markdown_result.stdout,
+        )
+
     def test_render_audit_report_markdown_renders_unknown_clinic_summary(self):
         result = run_script(
             "render_audit_report.py",
@@ -1631,7 +1650,57 @@ class PromptCacheScriptsTest(unittest.TestCase):
                 self.assertIn(
                     f"Usage denominator status: {denominator}", markdown_result.stdout
                 )
+                self.assertRegex(
+                    markdown_result.stdout,
+                    rf"Cache hit ratio: .*non-decision-grade; denominator {denominator}",
+                )
                 self.assertNotIn("Observed cache benefit on", markdown_result.stdout)
+
+    def test_render_audit_report_qualifies_empty_evidence_ratio(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            usage_path = self.write_usage_log(tmp, ())
+            result = run_script(
+                "render_audit_report.py",
+                "--usage-log",
+                usage_path,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "Cache hit ratio: 0 (non-decision-grade; denominator ambiguous)",
+            result.stdout,
+        )
+
+    def test_render_audit_report_keeps_denominator_caveat_with_roi(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            usage_path = self.write_usage_log(tmp, self.INVALID_USAGE_RECORDS)
+            roi_path = Path(tmp) / "roi.json"
+            roi_path.write_text(
+                json.dumps(
+                    {
+                        "producer": "estimate_cache_roi.py",
+                        "schema_version": 1,
+                        "pricing": {},
+                        "cache_read_input_cost": 0.1,
+                        "cache_write_input_cost": 0.0,
+                        "total_baseline_cost": 1.0,
+                        "total_with_cache_cost": 0.5,
+                        "total_savings": 0.5,
+                    }
+                )
+            )
+            result = run_script(
+                "render_audit_report.py",
+                "--usage-log",
+                usage_path,
+                "--roi-json",
+                roi_path,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("estimates $0.500000 in savings", result.stdout)
+        self.assertIn("Usage denominator status is invalid", result.stdout)
+        self.assertIn("must not support a savings claim", result.stdout)
 
     def test_render_audit_report_has_no_aggregate_clinic_rollup(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1659,9 +1728,21 @@ class PromptCacheScriptsTest(unittest.TestCase):
         self.assertEqual(json_result.returncode, 0, json_result.stderr)
         output = json.loads(json_result.stdout)
         forbidden = ("score", "rank", "grade", "percentage", "rollup", "traffic_light")
-        for key in list(output) + list(output["clinic_summary"]):
+        def nested_keys(value):
+            if isinstance(value, dict):
+                for key, child in value.items():
+                    yield key
+                    yield from nested_keys(child)
+            elif isinstance(value, list):
+                for child in value:
+                    yield from nested_keys(child)
+
+        for key in nested_keys(output):
             self.assertFalse(
-                any(token in key for token in forbidden),
+                any(
+                    f"clinic_{token}" in key or f"{token}_clinic" in key
+                    for token in forbidden
+                ),
                 f"unexpected aggregate key: {key}",
             )
         self.assertEqual(json_result.returncode, 0)


### PR DESCRIPTION
## Summary

- add field-level usage provenance, event schema versioning, and `denominator_status` across OpenAI, Anthropic, Bedrock, Gemini, and unknown-wrapper adapters
- validate inclusive cache components and aggregate read/write totals so ambiguous or impossible hit ratios cannot be treated as decision-grade evidence
- add explicit cache-plane selection and a seven-dimension Cache Clinic Summary without an aggregate score
- update the skill, pressure evals, README, design, implementation plan, and plugin-eval review artifacts

## Why

Cache reports could show a precise hit ratio while the raw provider fields, inclusive/additive accounting, or cache layer were unclear. That made gateway response caching, provider prompt caching, engine KV reuse, and other cache planes easy to conflate and could allow invalid usage accounting to support a savings claim.

## Impact

- normalized JSONL events expose exact source paths without retaining raw envelopes
- ambiguous and invalid denominators qualify hit-rate and cost output as non-decision-grade
- known wrapper accounting can be resolved explicitly with `--accounting-mode inclusive|additive`
- reports preserve unknown clinic dimensions instead of hiding them in a score
- existing CLI arguments and existing JSON keys remain available

## Validation

- `python3 -m unittest tests/test_prompt_cache_scripts.py` — 131 tests passed
- `python3 audit-prompt-caching/scripts/validate_skill_package.py audit-prompt-caching` — passed
- `python3 audit-prompt-caching/scripts/run_trigger_eval.py audit-prompt-caching` — 24 cases passed
- Python syntax compilation — passed
- `git diff --check origin/main...HEAD` — passed
- plugin-eval: 54/F → 68/D; trigger tokens 170 → 135; invoke tokens 5,852 → 5,850; no new failures

## Notes

The plugin-eval deferred-token estimate increased because the change adds production contracts, pressure scenarios, and durable review artifacts. The package-local test-discovery warning remains a layout false positive: the repository test suite lives in the root `tests/` directory and is included in the validation above.
